### PR TITLE
Reconciling limits `ConfigMap`

### DIFF
--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -79,6 +79,17 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - apps
           resources:
           - deployments

--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -11,6 +11,25 @@ metadata:
             "name": "limitador-sample"
           },
           "spec": {
+            "limits": [
+              {
+                "conditions": [
+                  "get-toy == yes"
+                ],
+                "max_value": 2,
+                "namespace": "toystore-app",
+                "seconds": 30,
+                "variables": []
+              }
+            ],
+            "listener": {
+              "grpc": {
+                "port": 8081
+              },
+              "http": {
+                "port": 8080
+              }
+            },
             "replicas": 1,
             "version": "latest"
           }

--- a/config/deploy/manfiests.yaml
+++ b/config/deploy/manfiests.yaml
@@ -225,6 +225,17 @@ metadata:
   name: limitador-operator-manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/config/install/manifests.yaml
+++ b/config/install/manifests.yaml
@@ -218,6 +218,17 @@ metadata:
   name: limitador-operatormanager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,17 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/config/samples/limitador_v1alpha1_limitador.yaml
+++ b/config/samples/limitador_v1alpha1_limitador.yaml
@@ -5,3 +5,14 @@ metadata:
 spec:
   replicas: 1
   version: latest
+  listener:
+    http:
+      port: 8080
+    grpc:
+      port: 8081
+  limits:
+    - conditions: ["get-toy == yes"]
+      max_value: 2
+      namespace: toystore-app
+      seconds: 30
+      variables: []

--- a/controllers/limitador_controller.go
+++ b/controllers/limitador_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/kuadrant/limitador-operator/pkg/helpers"
+	v1 "k8s.io/api/core/v1"
 	"strconv"
 
 	"github.com/go-logr/logr"
@@ -86,6 +87,17 @@ func (r *LimitadorReconciler) Reconcile(eventCtx context.Context, req ctrl.Reque
 		return ctrl.Result{}, err
 	}
 
+	// Reconcile Limits ConfigMap
+	limitsConfigMap, err := limitador.LimitsConfigMap(limitadorObj)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	err = r.ReconcileConfigMap(ctx, limitsConfigMap, mutateLimitsConfigMap)
+	logger.V(1).Info("reconcile limits ConfigMap", "error", err)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	return ctrl.Result{}, nil
 }
 
@@ -114,6 +126,30 @@ func buildServiceUrl(limitadorObj *limitadorv1alpha1.Limitador) string {
 		limitadorObj.Name + "." +
 		limitadorObj.Namespace + ".svc.cluster.local:" +
 		strconv.Itoa(int(helpers.GetValueOrDefault(*limitadorObj.Spec.Listener.HTTP.Port, limitador.DefaultServiceHTTPPort).(int32)))
+}
+
+func mutateLimitsConfigMap(existingObj, desiredObj client.Object) (bool, error) {
+	existing, ok := existingObj.(*v1.ConfigMap)
+	if !ok {
+		return false, fmt.Errorf("%T is not a *v1.ConfigMap", existingObj)
+	}
+	desired, ok := desiredObj.(*v1.ConfigMap)
+	if !ok {
+		return false, fmt.Errorf("%T is not a *v1.ConfigMap", desiredObj)
+	}
+
+	updated := false
+
+	if existing.Data[limitador.LimitadorCMHash] != desired.Data[limitador.LimitadorCMHash] {
+		for k, v := range map[string]string{
+			limitador.LimitadorCMHash:         desired.Data[limitador.LimitadorCMHash],
+			limitador.LimitadorConfigFileName: string(desired.Data[limitador.LimitadorConfigFileName]),
+		} {
+			existing.Data[k] = v
+		}
+		updated = true
+	}
+	return updated, nil
 }
 
 func mutateLimitadorDeployment(existingObj, desiredObj client.Object) (bool, error) {

--- a/controllers/limitador_controller.go
+++ b/controllers/limitador_controller.go
@@ -44,6 +44,7 @@ type LimitadorReconciler struct {
 //+kubebuilder:rbac:groups=limitador.kuadrant.io,resources=limitadors/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;delete
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;delete
 
 func (r *LimitadorReconciler) Reconcile(eventCtx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Logger().WithValues("limitador", req.NamespacedName)

--- a/controllers/limitador_controller_test.go
+++ b/controllers/limitador_controller_test.go
@@ -115,10 +115,10 @@ var _ = Describe("Limitador controller", func() {
 				Equal(LimitadorImage + ":" + LimitadorVersion),
 			)
 			Expect(createdLimitadorDeployment.Spec.Template.Spec.Containers[0].Env[1]).Should(
-				Equal(v1.EnvVar{Name: "LIMITS_FILE", Value: "/limitador-config.yaml", ValueFrom: nil}),
+				Equal(v1.EnvVar{Name: "LIMITS_FILE", Value: "/home/limitador/etc/limitador-config.yaml", ValueFrom: nil}),
 			)
 			Expect(createdLimitadorDeployment.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).Should(
-				Equal("/"),
+				Equal("/home/limitador/etc/"),
 			)
 			Expect(createdLimitadorDeployment.Spec.Template.Spec.Volumes[0].VolumeSource.ConfigMap.Name).Should(
 				Equal(limitador.LimitsCMNamePrefix + limitadorObj.Name),
@@ -267,11 +267,11 @@ var _ = Describe("Limitador controller", func() {
 					return false
 				}
 
-				correctHash := updatedLimitadorConfigMap.Data[limitador.LimitadorCMHash] == "69b3eab828208274d4200aedc6fd8b19"
-				correctLimits := updatedLimitadorConfigMap.Data[limitador.LimitadorConfigFileName] == "- conditions:\n  - req.method == GET\n  max_value: 100\n  namespace: test-namespace\n  seconds: 60\n  variables:\n  - user_id\n"
-
-				return correctHash && correctLimits
+				return true
 			}, timeout, interval).Should(BeTrue())
+			Expect(updatedLimitadorConfigMap.Data[limitador.LimitadorCMHash]).Should(Equal("69b3eab828208274d4200aedc6fd8b19"))
+			Expect(updatedLimitadorConfigMap.Data[limitador.LimitadorConfigFileName]).Should(Equal("- conditions:\n  - req.method == GET\n  max_value: 100\n  namespace: test-namespace\n  seconds: 60\n  variables:\n  - user_id\n"))
+
 		})
 	})
 })

--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,5 @@ require (
 	k8s.io/client-go v0.22.1
 	k8s.io/klog/v2 v2.9.0
 	sigs.k8s.io/controller-runtime v0.10.0
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/go-logr/logr v0.4.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.15.0
-	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.19.0
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.22.1
@@ -14,5 +13,5 @@ require (
 	k8s.io/client-go v0.22.1
 	k8s.io/klog/v2 v2.9.0
 	sigs.k8s.io/controller-runtime v0.10.0
-	sigs.k8s.io/yaml v1.2.0 // indirect
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/pkg/limitador/k8s_objects.go
+++ b/pkg/limitador/k8s_objects.go
@@ -13,21 +13,17 @@ import (
 )
 
 const (
-	DefaultVersion             = "latest"
-	DefaultReplicas            = 1
-	Image                      = "quay.io/3scale/limitador"
-	StatusEndpoint             = "/status"
-	DefaultServiceHTTPPort     = 8080
-	DefaultServiceGRPCPort     = 8081
-	EnvLimitadorConfigFileName = "LIMITADOR_CONFIG_FILE_NAME"
-	LimitadorCMHash            = "hash"
-	LimitsCMNamePrefix         = "limits-config-"
-	LimitadorCMMountPath       = "/"
-	LimitadorLimitsFileEnv     = "LIMITS_FILE"
-)
-
-var (
-	LimitadorConfigFileName = helpers.FetchEnv(EnvLimitadorConfigFileName, "limitador-config.yaml")
+	DefaultVersion          = "latest"
+	DefaultReplicas         = 1
+	Image                   = "quay.io/3scale/limitador"
+	StatusEndpoint          = "/status"
+	DefaultServiceHTTPPort  = 8080
+	DefaultServiceGRPCPort  = 8081
+	LimitadorConfigFileName = "limitador-config.yaml"
+	LimitadorCMHash         = "hash"
+	LimitsCMNamePrefix      = "limits-config-"
+	LimitadorCMMountPath    = "/home/limitador/etc/"
+	LimitadorLimitsFileEnv  = "LIMITS_FILE"
 )
 
 func LimitadorService(limitador *limitadorv1alpha1.Limitador) *v1.Service {

--- a/pkg/limitador/k8s_objects_test.go
+++ b/pkg/limitador/k8s_objects_test.go
@@ -1,0 +1,22 @@
+package limitador
+
+import (
+	"gotest.tools/assert"
+	"testing"
+)
+
+func TestConstants(t *testing.T) {
+	assert.Check(t, "latest" == DefaultVersion)
+	assert.Check(t, 1 == DefaultReplicas)
+	assert.Check(t, "quay.io/3scale/limitador" == Image)
+	assert.Check(t, "/status" == StatusEndpoint)
+	assert.Check(t, 8080 == DefaultServiceHTTPPort)
+	assert.Check(t, 8081 == DefaultServiceGRPCPort)
+	assert.Check(t, "LIMITADOR_CONFIG_FILE_NAME" == EnvLimitadorConfigFileName)
+	assert.Check(t, "hash" == LimitadorCMHash)
+	assert.Check(t, "limits-config-" == LimitsCMNamePrefix)
+	assert.Check(t, "/" == LimitadorCMMountPath)
+	assert.Check(t, "LIMITS_FILE" == LimitadorLimitsFileEnv)
+}
+
+//TODO: Test individual k8s objects. Extract limitadorObj creation from controller_test

--- a/pkg/limitador/k8s_objects_test.go
+++ b/pkg/limitador/k8s_objects_test.go
@@ -12,10 +12,10 @@ func TestConstants(t *testing.T) {
 	assert.Check(t, "/status" == StatusEndpoint)
 	assert.Check(t, 8080 == DefaultServiceHTTPPort)
 	assert.Check(t, 8081 == DefaultServiceGRPCPort)
-	assert.Check(t, "LIMITADOR_CONFIG_FILE_NAME" == EnvLimitadorConfigFileName)
+	assert.Check(t, "limitador-config.yaml" == LimitadorConfigFileName)
 	assert.Check(t, "hash" == LimitadorCMHash)
 	assert.Check(t, "limits-config-" == LimitsCMNamePrefix)
-	assert.Check(t, "/" == LimitadorCMMountPath)
+	assert.Check(t, "/home/limitador/etc/" == LimitadorCMMountPath)
 	assert.Check(t, "LIMITS_FILE" == LimitadorLimitsFileEnv)
 }
 

--- a/pkg/reconcilers/base_reconciler.go
+++ b/pkg/reconcilers/base_reconciler.go
@@ -18,7 +18,6 @@ package reconcilers
 
 import (
 	"context"
-
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -142,6 +141,10 @@ func (b *BaseReconciler) ReconcileService(ctx context.Context, desired *corev1.S
 
 func (b *BaseReconciler) ReconcileDeployment(ctx context.Context, desired *appsv1.Deployment, mutatefn MutateFn) error {
 	return b.ReconcileResource(ctx, &appsv1.Deployment{}, desired, mutatefn)
+}
+
+func (b *BaseReconciler) ReconcileConfigMap(ctx context.Context, desired *corev1.ConfigMap, mutatefn MutateFn) error {
+	return b.ReconcileResource(ctx, &corev1.ConfigMap{}, desired, mutatefn)
 }
 
 func (b *BaseReconciler) GetResource(ctx context.Context, objKey types.NamespacedName, obj client.Object) error {


### PR DESCRIPTION
Closes https://github.com/Kuadrant/limitador-operator/issues/27

This PR introduces the `ConfigMap` that holds the _state_ and _limits_ (configuration needed for setting up _Limitador_) which it's reconciled by the _limitador-controller_

The `ConfigMap` looks like:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  labels:
    app: limitador
  name: limits-config-limitador-1 # Name constructed from "limits-config-" prefix and the `Limitador` CR name
data:
  hash: 32trgresg3ydsagas # hash built from the actual limits. Used for reconciling (state)
  limitador-config.yaml: |
  limits:
  - conditions: ["get-toy == yes"]
    max_value: 2
    namespace: toystore-app
    seconds: 30
    variables: []
  - conditions:
    - "admin == yes"
    max_value: 2
    namespace: toystore-app
    seconds: 30
    variables: []
  - conditions: ["vhaction == yes"]
    max_value: 6
    namespace: toystore-app
    seconds: 30
    variables: []            
```                                

And the file it's fed to the deployment env varialbe `LIMITS_FILE` and mounted as a _Volume_ to it`s deployment.

**Verification steps:**

1. Lunch the cluster setup with `make local-setup`
2. When ready, create a new namespace like `kubectl create namespace "limitador-test"`
3. Then, apply the following Limitador CR:
```bash
kubectl -n limitador-test apply -f -<<EOF
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador
spec:
  replicas: 1
  version: "0.4.0"
  listener:
    http:
      port: 8080
    grpc:
      port: 8081
  limits:
    - conditions: ["get-toy == yes"]
      max_value: 2
      namespace: toystore-app
      seconds: 30
      variables: []
EOF

```
4. Then between the couple of things that got crated by the operator, you should see the following `ConfigMap`:
```bash
k -n limitador-test get cm/limits-config-limitador -o yaml
apiVersion: v1
data:
  hash: c7fabb796b22ffef0a4207da931d67bd
  limitador-config.yaml: |
    - conditions:
      - get-toy == yes
      max_value: 2
      namespace: toystore-app
      seconds: 30
      variables: []
kind: ConfigMap
metadata:
  creationTimestamp: "2022-06-27T16:27:20Z"
  labels:
    app: limitador
  name: limits-config-limitador
  namespace: limitador-test
  resourceVersion: "1311"
  uid: a326cea3-80ba-4ef4-976f-aa75f9e7157c
```
                  