### PR TITLE
remove kube-rbac-proxy sidecar

### DIFF
--- a/bundle/manifests/limitador-operator-manager-config_v1_configmap.yaml
+++ b/bundle/manifests/limitador-operator-manager-config_v1_configmap.yaml
@@ -6,7 +6,7 @@ data:
     health:
       healthProbeBindAddress: :8081
     metrics:
-      bindAddress: 127.0.0.1:8080
+      bindAddress: :8080
     webhook:
       port: 9443
     leaderElection:

--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -137,18 +137,6 @@ spec:
           - get
           - patch
           - update
-        - apiGroups:
-          - authentication.k8s.io
-          resources:
-          - tokenreviews
-          verbs:
-          - create
-        - apiGroups:
-          - authorization.k8s.io
-          resources:
-          - subjectaccessreviews
-          verbs:
-          - create
         serviceAccountName: limitador-operator-controller-manager
       deployments:
       - label:
@@ -167,19 +155,6 @@ spec:
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                resources: {}
-              - args:
-                - --health-probe-bind-address=:8081
-                - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 command:
                 - /manager
@@ -191,6 +166,9 @@ spec:
                   initialDelaySeconds: 15
                   periodSeconds: 20
                 name: manager
+                ports:
+                - containerPort: 8080
+                  name: metrics
                 readinessProbe:
                   httpGet:
                     path: /readyz

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -28,7 +28,8 @@ patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+# - manager_auth_proxy_patch.yaml
+- manager_metrics_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 8080
+          name: metrics

--- a/config/deploy/manfiests.yaml
+++ b/config/deploy/manfiests.yaml
@@ -285,34 +285,6 @@ rules:
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: limitador-operator-metrics-reader
-rules:
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: limitador-operator-proxy-role
-rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: limitador-operator-leader-election-rolebinding
@@ -339,19 +311,6 @@ subjects:
   name: limitador-operator-controller-manager
   namespace: limitador-operator-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: limitador-operator-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: limitador-operator-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: limitador-operator-controller-manager
-  namespace: limitador-operator-system
----
 apiVersion: v1
 data:
   controller_manager_config.yaml: |
@@ -360,7 +319,7 @@ data:
     health:
       healthProbeBindAddress: :8081
     metrics:
-      bindAddress: 127.0.0.1:8080
+      bindAddress: :8080
     webhook:
       port: 9443
     leaderElection:
@@ -380,9 +339,9 @@ metadata:
   namespace: limitador-operator-system
 spec:
   ports:
-  - name: https
-    port: 8443
-    targetPort: https
+  - name: metrics
+    port: 8080
+    targetPort: metrics
   selector:
     control-plane: controller-manager
 ---
@@ -405,18 +364,6 @@ spec:
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-      - args:
-        - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         command:
         - /manager
@@ -428,6 +375,9 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 20
         name: manager
+        ports:
+        - containerPort: 8080
+          name: metrics
         readinessProbe:
           httpGet:
             path: /readyz

--- a/config/install/manifests.yaml
+++ b/config/install/manifests.yaml
@@ -278,34 +278,6 @@ rules:
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: limitador-operatormetrics-reader
-rules:
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: limitador-operatorproxy-role
-rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: limitador-operatorleader-election-rolebinding
@@ -331,31 +303,3 @@ subjects:
 - kind: ServiceAccount
   name: limitador-operatorcontroller-manager
   namespace: limitador-operator
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: limitador-operatorproxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: limitador-operatorproxy-role
-subjects:
-- kind: ServiceAccount
-  name: limitador-operatorcontroller-manager
-  namespace: limitador-operator
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    control-plane: controller-manager
-  name: limitador-operatorcontroller-manager-metrics-service
-  namespace: limitador-operator
-spec:
-  ports:
-  - name: https
-    port: 8443
-    targetPort: https
-  selector:
-    control-plane: controller-manager

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -3,7 +3,7 @@ kind: ControllerManagerConfig
 health:
   healthProbeBindAddress: :8081
 metrics:
-  bindAddress: 127.0.0.1:8080
+  bindAddress: :8080
 webhook:
   port: 9443
 leaderElection:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- metrics_service.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/config/manager/metrics_service.yaml
+++ b/config/manager/metrics_service.yaml
@@ -1,10 +1,11 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     control-plane: controller-manager
-  name: limitador-operator-controller-manager-metrics-service
+  name: controller-manager-metrics-service
+  namespace: system
 spec:
   ports:
   - name: metrics
@@ -12,5 +13,3 @@ spec:
     targetPort: metrics
   selector:
     control-plane: controller-manager
-status:
-  loadBalancer: {}

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -10,11 +10,8 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: https
-      scheme: https
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tlsConfig:
-        insecureSkipVerify: true
+      port: metrics
+      scheme: http
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-- auth_proxy_service.yaml
-- auth_proxy_role.yaml
-- auth_proxy_role_binding.yaml
-- auth_proxy_client_clusterrole.yaml
+#- auth_proxy_service.yaml
+#- auth_proxy_role.yaml
+#- auth_proxy_role_binding.yaml
+#- auth_proxy_client_clusterrole.yaml


### PR DESCRIPTION
# What

Remove the kube-rbac-proxy container from the controller-manager

https://github.com/Kuadrant/kuadrant-operator/pull/7#discussion_r797439423

# Why

See:

    https://github.com/3scale/3scale-operator/pull/692
    https://github.com/3scale-ops/prometheus-exporter-operator/pull/26

# Verification steps

* deploy limitador locally
```
make local-setup
```
* Expose metrics service locally
```
kubectl port-forward --namespace limitador-operator-system service/limitador-operator-controller-manager-metrics-service 8080:8080
```

* [X] No need to add RBAC access token
```
$ curl http://127.0.0.1:8080/metrics
# HELP controller_runtime_active_workers Number of currently used workers per controller
# TYPE controller_runtime_active_workers gauge
controller_runtime_active_workers{controller="limitador"} 0
# HELP controller_runtime_max_concurrent_reconciles Maximum number of concurrent reconciles per controller
# TYPE controller_runtime_max_concurrent_reconciles gauge
controller_runtime_max_concurrent_reconciles{controller="limitador"} 1
# HELP controller_runtime_reconcile_errors_total Total number of reconciliation errors per controller
# TYPE controller_runtime_reconcile_errors_total counter
controller_runtime_reconcile_errors_total{controller="limitador"} 0
....
```