### PR TITLE
Enhance status reconciling cycle

### DIFF
--- a/controllers/limitador_controller.go
+++ b/controllers/limitador_controller.go
@@ -217,7 +217,7 @@ func updateStatusConditions(currentConditions []metav1.Condition, newCondition m
 }
 
 func buildServiceHost(limitadorObj *limitadorv1alpha1.Limitador) string {
-	return fmt.Sprintf("%s.%s.svc.cluster.local", limitadorObj.Name, limitadorObj.Namespace)
+	return fmt.Sprintf("%s.%s.svc.cluster.local", limitador.ServiceName(limitadorObj), limitadorObj.Namespace)
 }
 
 func mutateLimitsConfigMap(existingObj, desiredObj client.Object) (bool, error) {

--- a/controllers/limitador_controller_test.go
+++ b/controllers/limitador_controller_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Limitador controller", func() {
 					&createdLimitador)
 				return createdLimitador.Status.Service
 			}, timeout, interval).Should(Equal(limitadorv1alpha1.LimitadorService{
-				Host: limitadorObj.Name + ".default.svc.cluster.local",
+				Host: "limitador-" + limitadorObj.Name + ".default.svc.cluster.local",
 				Ports: limitadorv1alpha1.Ports{
 					GRPC: grpcPortNumber,
 					HTTP: httpPortNumber,

--- a/pkg/limitador/k8s_objects.go
+++ b/pkg/limitador/k8s_objects.go
@@ -190,6 +190,10 @@ func LimitsConfigMap(limitador *limitadorv1alpha1.Limitador) (*v1.ConfigMap, err
 	}, nil
 }
 
+func ServiceName(limitadorObj *limitadorv1alpha1.Limitador) string {
+	return fmt.Sprintf("limitador-%s", limitadorObj.Name)
+}
+
 func labels() map[string]string {
 	return map[string]string{"app": "limitador"}
 }

--- a/pkg/limitador/k8s_objects_test.go
+++ b/pkg/limitador/k8s_objects_test.go
@@ -3,7 +3,9 @@ package limitador
 import (
 	"testing"
 
+	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 	"gotest.tools/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestConstants(t *testing.T) {
@@ -18,4 +20,37 @@ func TestConstants(t *testing.T) {
 	assert.Check(t, "LIMITS_FILE" == LimitadorLimitsFileEnv)
 }
 
-//TODO: Test individual k8s objects. Extract limitadorObj creation from controller_test
+//TODO: Test individual k8s objects.
+func newTestLimitadorObj(name, namespace string, limits []limitadorv1alpha1.RateLimit) *limitadorv1alpha1.Limitador {
+	var (
+		replicas = 1
+		version  = "1.0"
+		httpPort = int32(8000)
+		grpcPort = int32(8001)
+	)
+	return &limitadorv1alpha1.Limitador{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Limitador",
+			APIVersion: "limitador.kuadrant.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: limitadorv1alpha1.LimitadorSpec{
+			Replicas: &replicas,
+			Version:  &version,
+			Listener: &limitadorv1alpha1.Listener{
+				HTTP: &limitadorv1alpha1.TransportProtocol{Port: &httpPort},
+				GRPC: &limitadorv1alpha1.TransportProtocol{Port: &grpcPort},
+			},
+			Limits: limits,
+		},
+	}
+
+}
+
+func TestServiceName(t *testing.T) {
+	name := ServiceName(newTestLimitadorObj("my-limitador-instance", "default", nil))
+	assert.Equal(t, name, "limitador-my-limitador-instance")
+}


### PR DESCRIPTION
This PR enhance the `Limitador.Status` reconciling process, instead of requeueing every time it checks the status is not ready, now it will just watch the owned `Deployment` obj, and update its `Limitador.Status` once the deployment has changed its and it has enough `ReadyReplicas`.
It also fixes the Limitador Service Name generation and error reporting when it's instance is not found, or raised an error.

Closes https://github.com/Kuadrant/limitador-operator/issues/35

*Verification Steps:*
1. Lunch the cluster setup with 
```bash
make local-setup
```
2. When ready, create a new namespace:
```bash
kubectl create namespace "limitador-test"
```
3. Then, apply the following Limitador CR:
```bash
k -n limitador-test apply -f - <<EOF
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador-sample
spec:  {}
EOF
```

4. Then after the operator created the deployment, service,configmaps, etc... you could check the status of the limitador CR:
```bash
k -n limitador-test get limitador/limitador-sample -o yaml
```
```yaml
...
Status:
  Conditions:
    Last Transition Time:  2022-08-10T10:06:08Z
    Message:             ""
    Reason:                LimitadorInstanceRunning
    Status:                 True
    Type:                   Ready
  Service:
    Host:  limitador-sample.limitador-test.svc.cluster.local
    Ports:
      Grpc:  8081
      Http:  8080
```

