### PR TITLE
limitador version from env var

### DIFF
--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -135,6 +135,9 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
+                env:
+                - name: RELATED_IMAGE_LIMITADOR
+                  value: quay.io/3scale/limitador:latest
                 image: quay.io/kuadrant/limitador-operator:latest
                 livenessProbe:
                   httpGet:
@@ -212,4 +215,7 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/limitador-operator
+  relatedImages:
+  - image: quay.io/3scale/limitador:latest
+    name: limitador
   version: 0.0.0

--- a/config/deploy/manfiests.yaml
+++ b/config/deploy/manfiests.yaml
@@ -372,6 +372,9 @@ spec:
         - --leader-elect
         command:
         - /manager
+        env:
+        - name: RELATED_IMAGE_LIMITADOR
+          value: quay.io/3scale/limitador:latest
         image: quay.io/kuadrant/limitador-operator:latest
         livenessProbe:
           httpGet:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,6 +29,9 @@ spec:
         - /manager
         args:
         - --leader-elect
+        env:
+        - name: RELATED_IMAGE_LIMITADOR
+          value: "quay.io/3scale/limitador:latest"
         image: controller:latest
         name: manager
         securityContext:

--- a/pkg/limitador/image.go
+++ b/pkg/limitador/image.go
@@ -1,0 +1,15 @@
+package limitador
+
+import (
+	"fmt"
+
+	"github.com/kuadrant/limitador-operator/pkg/helpers"
+)
+
+var (
+	defaultImageVersion = fmt.Sprintf("%s:%s", LimitadorRepository, "latest")
+)
+
+func GetLimitadorImageVersion() string {
+	return helpers.FetchEnv("RELATED_IMAGE_LIMITADOR", defaultImageVersion)
+}

--- a/pkg/limitador/image_test.go
+++ b/pkg/limitador/image_test.go
@@ -1,0 +1,11 @@
+package limitador
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestLimitadorDefaulImage(t *testing.T) {
+	assert.Equal(t, GetLimitadorImageVersion(), "quay.io/3scale/limitador:latest")
+}

--- a/pkg/limitador/k8s_objects.go
+++ b/pkg/limitador/k8s_objects.go
@@ -4,18 +4,18 @@ import (
 	"crypto/md5"
 	"fmt"
 
-	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/yaml"
+
+	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 )
 
 const (
-	DefaultVersion          = "latest"
 	DefaultReplicas         = 1
-	Image                   = "quay.io/3scale/limitador"
+	LimitadorRepository     = "quay.io/3scale/limitador"
 	StatusEndpoint          = "/status"
 	LimitadorConfigFileName = "limitador-config.yaml"
 	LimitadorCMHash         = "hash"
@@ -64,9 +64,9 @@ func LimitadorDeployment(limitador *limitadorv1alpha1.Limitador) *appsv1.Deploym
 		replicas = int32(*limitador.Spec.Replicas)
 	}
 
-	version := DefaultVersion
+	image := GetLimitadorImageVersion()
 	if limitador.Spec.Version != nil {
-		version = *limitador.Spec.Version
+		image = fmt.Sprintf("%s:%s", LimitadorRepository, *limitador.Spec.Version)
 	}
 
 	return &appsv1.Deployment{
@@ -93,7 +93,7 @@ func LimitadorDeployment(limitador *limitadorv1alpha1.Limitador) *appsv1.Deploym
 					Containers: []v1.Container{
 						{
 							Name:  "limitador",
-							Image: Image + ":" + version,
+							Image: image,
 							Ports: []v1.ContainerPort{
 								{
 									Name:          "http",

--- a/pkg/limitador/k8s_objects_test.go
+++ b/pkg/limitador/k8s_objects_test.go
@@ -9,9 +9,8 @@ import (
 )
 
 func TestConstants(t *testing.T) {
-	assert.Check(t, "latest" == DefaultVersion)
 	assert.Check(t, 1 == DefaultReplicas)
-	assert.Check(t, "quay.io/3scale/limitador" == Image)
+	assert.Check(t, "quay.io/3scale/limitador" == LimitadorRepository)
 	assert.Check(t, "/status" == StatusEndpoint)
 	assert.Check(t, "limitador-config.yaml" == LimitadorConfigFileName)
 	assert.Check(t, "hash" == LimitadorCMHash)
@@ -47,7 +46,6 @@ func newTestLimitadorObj(name, namespace string, limits []limitadorv1alpha1.Rate
 			Limits: limits,
 		},
 	}
-
 }
 
 func TestServiceName(t *testing.T) {


### PR DESCRIPTION
### what

Limitador image can be read from `RELATED_IMAGE_LIMITADOR` env var. Defaults to `quay.io/3scale/limitador:latest`-

Required to specify the limitador image from the CSV manifest

`spec.version` will override any value from `RELATED_IMAGE_LIMITADOR`.

The limitador image order of preference is:
* `spec.version` value (only allows tag, repo will alway be `quay.io/3scale/limitador`
* value from `RELATED_IMAGE_LIMITADOR` env var. Image repo and tag needs to be specified. For example: `quay.io/3scale/limitador:0.5.1`
* Default value: `quay.io/3scale/limitador:latest`

### Verification steps

run cluster
```
make local-setup-kind
```

install CRDs
```
make install
```

run operator locally with specific `RELATED_IMAGE_LIMITADOR` env var.

```
RELATED_IMAGE_LIMITADOR=quay.io/3scale/limitador:0.5.1 make run
```

Create Limitador object without `spec.version` to deploy version from env var.
```yaml
k apply -f - <<EOF
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador-sample
spec:
  limits:
    - conditions: ["get-toy == yes"]
      max_value: 2
      namespace: toystore-app
      seconds: 30
      variables: []
EOF
```

Check limitador's version is `quay.io/3scale/limitador:0.5.1`
```
$ k get deployment limitador-sample -o yaml | yq e '.spec.template.spec.containers[0].image' -
quay.io/3scale/limitador:0.5.1
```