### PR TITLE
little fix in status reconcile

### DIFF
--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the limitador v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=limitador.kuadrant.io
+// +kubebuilder:object:generate=true
+// +groupName=limitador.kuadrant.io
 package v1alpha1
 
 import (

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -24,7 +24,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-	"github.com/onsi/gomega/ghttp"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,7 +41,6 @@ import (
 
 var k8sClient client.Client
 var testEnv *envtest.Environment
-var mockedHTTPServer *ghttp.Server
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/limitador/k8s_objects_test.go
+++ b/pkg/limitador/k8s_objects_test.go
@@ -20,7 +20,7 @@ func TestConstants(t *testing.T) {
 	assert.Check(t, "LIMITS_FILE" == LimitadorLimitsFileEnv)
 }
 
-//TODO: Test individual k8s objects.
+// TODO: Test individual k8s objects.
 func newTestLimitadorObj(name, namespace string, limits []limitadorv1alpha1.RateLimit) *limitadorv1alpha1.Limitador {
 	var (
 		replicas = 1

--- a/pkg/reconcilers/base_reconciler.go
+++ b/pkg/reconcilers/base_reconciler.go
@@ -96,8 +96,10 @@ func (b *BaseReconciler) EventRecorder() record.EventRecorder {
 // with the existing state inside the passed in callback MutateFn.
 //
 // obj: Object of the same type as the 'desired' object.
-//            Used to read the resource from the kubernetes cluster.
-//            Could be zero-valued initialized object.
+//
+//	Used to read the resource from the kubernetes cluster.
+//	Could be zero-valued initialized object.
+//
 // desired: Object representing the desired state
 //
 // It returns an error.
@@ -177,7 +179,7 @@ func (b *BaseReconciler) UpdateResourceStatus(ctx context.Context, obj client.Ob
 	return b.Client().Status().Update(ctx, obj)
 }
 
-//SetOwnerReference sets owner as a Controller OwnerReference on owned
+// SetOwnerReference sets owner as a Controller OwnerReference on owned
 func (b *BaseReconciler) SetOwnerReference(owner, obj client.Object) error {
 	err := controllerutil.SetControllerReference(owner, obj, b.Scheme())
 	if err != nil {
@@ -190,7 +192,7 @@ func (b *BaseReconciler) SetOwnerReference(owner, obj client.Object) error {
 	return err
 }
 
-//EnsureOwnerReference sets owner as a Controller OwnerReference on owned
+// EnsureOwnerReference sets owner as a Controller OwnerReference on owned
 // returns boolean to notify when the object has been updated
 func (b *BaseReconciler) EnsureOwnerReference(owner, obj client.Object) (bool, error) {
 	changed := false


### PR DESCRIPTION
* little fix in status reconcile. Avoid returning errors when limitador was not ready and  status did not change. Wait for a new reconciliation loop when the deployment object changes
* lint issues fixed