### PR TITLE
increase controller resources

### DIFF
--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -157,11 +157,11 @@ spec:
                   periodSeconds: 10
                 resources:
                   limits:
-                    cpu: 100m
-                    memory: 30Mi
+                    cpu: 200m
+                    memory: 300Mi
                   requests:
-                    cpu: 100m
-                    memory: 20Mi
+                    cpu: 200m
+                    memory: 200Mi
                 securityContext:
                   allowPrivilegeEscalation: false
               securityContext:

--- a/config/deploy/manfiests.yaml
+++ b/config/deploy/manfiests.yaml
@@ -394,11 +394,11 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 200m
+            memory: 300Mi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 200m
+            memory: 200Mi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,10 +50,10 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 200m
+            memory: 300Mi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 200m
+            memory: 200Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
### what

Increase controller resource to 
* Limits
  * cpu: 200m
  * mem: 300 MB
* Requests:
  * cpu: 200m
  * mem: 200MB

### why

I hit OOM issues when deployed the operator in Openshift. In k8s no OOM issues, though.