### PR TITLE
fix configmap reconciliation

### DIFF
--- a/pkg/limitador/k8s_objects.go
+++ b/pkg/limitador/k8s_objects.go
@@ -1,7 +1,6 @@
 package limitador
 
 import (
-	"crypto/md5"
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -18,7 +17,6 @@ const (
 	LimitadorRepository     = "quay.io/3scale/limitador"
 	StatusEndpoint          = "/status"
 	LimitadorConfigFileName = "limitador-config.yaml"
-	LimitadorCMHash         = "hash"
 	LimitsCMNamePrefix      = "limits-config-"
 	LimitadorCMMountPath    = "/home/limitador/etc/"
 	LimitadorLimitsFileEnv  = "LIMITS_FILE"
@@ -180,7 +178,6 @@ func LimitsConfigMap(limitador *limitadorv1alpha1.Limitador) (*v1.ConfigMap, err
 	return &v1.ConfigMap{
 		Data: map[string]string{
 			LimitadorConfigFileName: string(limitsMarshalled),
-			LimitadorCMHash:         fmt.Sprintf("%x", md5.Sum(limitsMarshalled)),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      LimitsCMNamePrefix + limitador.Name,

--- a/pkg/limitador/k8s_objects_test.go
+++ b/pkg/limitador/k8s_objects_test.go
@@ -13,7 +13,6 @@ func TestConstants(t *testing.T) {
 	assert.Check(t, "quay.io/3scale/limitador" == LimitadorRepository)
 	assert.Check(t, "/status" == StatusEndpoint)
 	assert.Check(t, "limitador-config.yaml" == LimitadorConfigFileName)
-	assert.Check(t, "hash" == LimitadorCMHash)
 	assert.Check(t, "limits-config-" == LimitsCMNamePrefix)
 	assert.Check(t, "/home/limitador/etc/" == LimitadorCMMountPath)
 	assert.Check(t, "LIMITS_FILE" == LimitadorLimitsFileEnv)


### PR DESCRIPTION
### what

* Limits config map reconciliation was based on a hash computed from a yaml serialized string. This PR change the approach to `reflect.DeepEqual` comparing method. The hash computation is sensitive to the order of the limit object keys (`variables`, `conditions`, `max_value`, ...). `reflect.DeepEqual` is not sensible when checking maps equality. Both of approaches are sensitive to the order of the list objects, and that is still a small enhancement to be done. 
* In controller test, have a better sync of updated objects from the controller. The test will check object's fields when it is for sure they have been updated by the controller.

### verification steps

run cluster
```
make local-setup
```

deploy limitador object
```
k apply -f config/samples/limitador_v1alpha1_limitador.yaml
```

Update limitador limits. Adding a new limit to the list.
```
kubectl patch limitador limitador-sample --type=json --patch='[{"op": "add", "path": "/spec/limits/-", "value": {"conditions": ["other == yes"], "max_value": 2, "namespace": "toystore-app", "seconds": 30, "variables": []} }]'
```

Check config map was updated

```yaml
k get cm limits-config-limitador-sample -o yaml | yq_k8s_clean 
apiVersion: v1
data:
  limitador-config.yaml: |
    - conditions:
      - get-toy == yes
      max_value: 2
      namespace: toystore-app
      seconds: 30
      variables: []
    - conditions:
      - other == yes
      max_value: 2
      namespace: toystore-app
      seconds: 30
      variables: []
kind: ConfigMap
metadata:
  creationTimestamp: "2022-08-25T13:46:48Z"
  labels:
    app: limitador
  name: limits-config-limitador-sample
  namespace: default
  resourceVersion: "4169"
  uid: 7ece53b9-457c-44e8-857e-6891e12024ac
```
