### PR TITLE
Replica reconciliation

### DIFF
--- a/pkg/reconcilers/deployment.go
+++ b/pkg/reconcilers/deployment.go
@@ -1,0 +1,66 @@
+package reconcilers
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DeploymentMutateFn is a function which mutates the existing Deployment into it's desired state.
+type DeploymentMutateFn func(desired, existing *appsv1.Deployment) bool
+
+func DeploymentMutator(opts ...DeploymentMutateFn) MutateFn {
+	return func(existingObj, desiredObj client.Object) (bool, error) {
+		existing, ok := existingObj.(*appsv1.Deployment)
+		if !ok {
+			return false, fmt.Errorf("%T is not a *appsv1.Deployment", existingObj)
+		}
+		desired, ok := desiredObj.(*appsv1.Deployment)
+		if !ok {
+			return false, fmt.Errorf("%T is not a *appsv1.Deployment", desiredObj)
+		}
+
+		update := false
+
+		// Loop through each option
+		for _, opt := range opts {
+			tmpUpdate := opt(desired, existing)
+			update = update || tmpUpdate
+		}
+
+		return update, nil
+	}
+}
+
+func DeploymentReplicasMutator(desired, existing *appsv1.Deployment) bool {
+	update := false
+
+	var existingReplicas int32 = 1
+	if existing.Spec.Replicas != nil {
+		existingReplicas = *existing.Spec.Replicas
+	}
+
+	var desiredReplicas int32 = 1
+	if desired.Spec.Replicas != nil {
+		desiredReplicas = *desired.Spec.Replicas
+	}
+
+	if desiredReplicas != existingReplicas {
+		existing.Spec.Replicas = &desiredReplicas
+		update = true
+	}
+
+	return update
+}
+
+func DeploymentImageMutator(desired, existing *appsv1.Deployment) bool {
+	update := false
+
+	if existing.Spec.Template.Spec.Containers[0].Image != desired.Spec.Template.Spec.Containers[0].Image {
+		existing.Spec.Template.Spec.Containers[0].Image = desired.Spec.Template.Spec.Containers[0].Image
+		update = true
+	}
+
+	return update
+}


### PR DESCRIPTION
### what 

Currently, when replicas are not set in the Limitador CR, the operator will enforce the replicas in the deployment object to 1. On each reconcilliation loop, the operator makes sure the replica value at the deployment matches the one specified in the CR.

The problem is that if the replica count is managed by some external controller (for example the HPA controller), the operator does not allow it and tries to update deployment's replica count with the one in the CR.

This PR enables the control over the replica by the limitador operator, **only** when it is specified in the Limitador CR. If it is not specified in the CR, the operator will not reconcile the replicas allowing other controller do so. 

### how

Reconciliation (implemented by the mutator) only added when the replicas field is set.

### verification steps

dev setup

```
make local-setup
```
Deploy the limitador CR, the CR must not include any `replicas` field.

```yaml
k apply -f - <<EOF
---
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador-sample
spec:
  limits:
    - conditions: ["get_toy == 'yes'"]
      max_value: 2
      namespace: toystore-app
      seconds: 30
      variables: []
EOF
```

Check the number of pods is 1

```
k get deployment limitador-sample
NAME               READY   UP-TO-DATE   AVAILABLE   AGE
limitador-sample   1/1     1            1           14s
```

Scale to 3 via the deployment
```
kubectl scale --replicas=3 deployment limitador-sample
```

Check the number of pods is 3
```
k get deployment limitador-sample
NAME               READY   UP-TO-DATE   AVAILABLE   AGE
limitador-sample   3/3     3            3           89s

k get pods
NAME                               READY   STATUS    RESTARTS   AGE
limitador-sample-b8ccb4575-6647n   1/1     Running   0          60s
limitador-sample-b8ccb4575-tw2vm   1/1     Running   0          99s
limitador-sample-b8ccb4575-wgnkx   1/1     Running   0          60s
```

Add replicas to the Limitador CR with a value of 2

```
k patch limitador limitador-sample --type merge --patch '{"spec":{"replicas": 2}}'
limitador.limitador.kuadrant.io/limitador-sample patched
```

Check the deployment has 2 replicas

```
k get deployment limitador-sample
NAME               READY   UP-TO-DATE   AVAILABLE   AGE
limitador-sample   2/2     2            2           3m12s

k get pods

NAME                               READY   STATUS    RESTARTS   AGE
limitador-sample-b8ccb4575-tw2vm   1/1     Running   0          3m39s
limitador-sample-b8ccb4575-wgnkx   1/1     Running   0          3m
```

As replicas are set explicitly in the CR, changes in the deployment will be reverted back. If we try to scale to 3 via the deployment

```
kubectl scale --replicas=3 deployment limitador-sample
```

The number of replicas will still be 2
```
k get deployment limitador-sample
NAME               READY   UP-TO-DATE   AVAILABLE   AGE
limitador-sample   2/2     2            2           3m12s

k get pods

NAME                               READY   STATUS    RESTARTS   AGE
limitador-sample-b8ccb4575-tw2vm   1/1     Running   0          3m39s
limitador-sample-b8ccb4575-wgnkx   1/1     Running   0          3m
```
