### PR TITLE
Fix owner reference type

### DIFF
--- a/pkg/limitador/k8s_objects.go
+++ b/pkg/limitador/k8s_objects.go
@@ -28,10 +28,9 @@ func LimitadorService(limitador *limitadorv1alpha1.Limitador) *v1.Service {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            ServiceName(limitador),
-			Namespace:       limitador.ObjectMeta.Namespace, // TODO: revisit later. For now assume same.
-			Labels:          labels(),
-			OwnerReferences: []metav1.OwnerReference{ownerRefToLimitador(limitador)},
+			Name:      ServiceName(limitador),
+			Namespace: limitador.ObjectMeta.Namespace, // TODO: revisit later. For now assume same.
+			Labels:    labels(),
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
@@ -72,10 +71,9 @@ func LimitadorDeployment(limitador *limitadorv1alpha1.Limitador, storageConfigSe
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            limitador.ObjectMeta.Name,      // TODO: revisit later. For now assume same.
-			Namespace:       limitador.ObjectMeta.Namespace, // TODO: revisit later. For now assume same.
-			Labels:          labels(),
-			OwnerReferences: []metav1.OwnerReference{ownerRefToLimitador(limitador)},
+			Name:      limitador.ObjectMeta.Name,      // TODO: revisit later. For now assume same.
+			Namespace: limitador.ObjectMeta.Namespace, // TODO: revisit later. For now assume same.
+			Labels:    labels(),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
@@ -183,15 +181,6 @@ func ServiceName(limitadorObj *limitadorv1alpha1.Limitador) string {
 
 func labels() map[string]string {
 	return map[string]string{"app": "limitador"}
-}
-
-func ownerRefToLimitador(limitador *limitadorv1alpha1.Limitador) metav1.OwnerReference {
-	return metav1.OwnerReference{
-		APIVersion: limitador.APIVersion,
-		Kind:       limitador.Kind,
-		Name:       limitador.Name,
-		UID:        limitador.UID,
-	}
 }
 
 func deploymentContainerCommand(storage *limitadorv1alpha1.Storage, storageConfigSecret *v1.Secret) []string {


### PR DESCRIPTION
### what

* Change owner references to *controller owner references*. Basically enables to watch to changes when owned by some limitador CR. 

not controller owner references:
```yaml
 ownerReferences:
  - apiVersion: limitador.kuadrant.io/v1alpha1
    kind: Limitador
    name: limitador-sample
    uid: 4a75619c-24c7-4f86-a48d-933fa9db97fb
```
controller owner references:
```yaml
  ownerReferences:
  - apiVersion: limitador.kuadrant.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: Limitador
    name: limitador-sample
    uid: 8d8b37c8-fc43-49f2-a1b6-570c52536ff4
```

* Add controller owner references to configmaps
* Add watch on owned configmaps. If externally the config map is changed, the operator will reconcile back to the desired state.


### verification steps
dev setup

```
make local-setup
```

Deploy the limitador CR

```yaml
k apply -f - <<EOF
---
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador-sample
spec:
  limits:
    - conditions: ["get_toy == 'yes'"]
      max_value: 2
      namespace: toystore-app
      seconds: 30
      variables: []
EOF
```

Check that the limits config map has the limits and the controller owner reference

```yaml
k get configmaps limits-config-limitador-sample -o yaml
apiVersion: v1
data:
  limitador-config.yaml: |
    - conditions:
      - get_toy == 'yes'
      max_value: 2
      namespace: toystore-app
      seconds: 30
      variables: []
kind: ConfigMap
metadata:
  creationTimestamp: "2022-10-10T14:02:49Z"
  labels:
    app: limitador
  name: limits-config-limitador-sample
  namespace: default
  ownerReferences:
  - apiVersion: limitador.kuadrant.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: Limitador
    name: limitador-sample
    uid: 8d8b37c8-fc43-49f2-a1b6-570c52536ff4
  resourceVersion: "2853"
  uid: 2867a79e-da3c-4139-9423-93b164697cd5
```

Now, try to change it manually. We are going to remove all the limits. 

```
k patch configmaps limits-config-limitador-sample --type merge --patch '{"data":{"limitador-config.yaml": "[]"}}'
```

The operator, watching the config map, should revert the change back and the config map should have the limits as specified in the Limitador CR.

```yaml
k get configmaps limits-config-limitador-sample -o jsonpath='{.data}' | yq e -P
limitador-config.yaml: |
  - conditions:
    - get_toy == 'yes'
    max_value: 2
    namespace: toystore-app
    seconds: 30
    variables: []
```