### PR TITLE
support invalid limits configmap

### DIFF
--- a/controllers/limitador_controller.go
+++ b/controllers/limitador_controller.go
@@ -236,7 +236,9 @@ func mutateLimitsConfigMap(existingObj, desiredObj client.Object) (bool, error) 
 	var existingLimits []limitadorv1alpha1.RateLimit
 	err = yaml.Unmarshal([]byte(existing.Data[limitador.LimitadorConfigFileName]), &existingLimits)
 	if err != nil {
-		return false, err
+		// if existing content cannot be parsed, leave existingLimits as nil, so the operator will
+		// enforce desired content.
+		existingLimits = nil
 	}
 
 	// TODO(eastizle): deepEqual returns false when the order in the list is not equal.


### PR DESCRIPTION
### what

If the limits config map, for whatever reason, does not have a valid content to be parsed into a limits array, the operator fails to reconcile and cannot recover. This fix, is to handle that error. So if a invalid content is found, revert to desired content.

### verification steps
dev setup

```
make local-setup
```

Deploy the limitador CR

```yaml
k apply -f - <<EOF
---
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador-sample
spec:
  limits:
    - conditions: ["get_toy == 'yes'"]
      max_value: 2
      namespace: toystore-app
      seconds: 30
      variables: []
EOF
```


Check that the limits config map content

```yaml
k get configmaps limits-config-limitador-sample -o jsonpath='{.data}' | yq e -P
limitador-config.yaml: |
  - conditions:
    - get_toy == 'yes'
    max_value: 2
    namespace: toystore-app
    seconds: 30
    variables: []
```

Now, try to change it manually. Add some invalid content

```
k patch configmaps limits-config-limitador-sample --type merge --patch '{"data":{"limitador-config.yaml": "my own stuff"}}'
```

The operator should read the invalid content, and revert the changes back to the desired limits.

```yaml
k get configmaps limits-config-limitador-sample -o jsonpath='{.data}' | yq e -P
limitador-config.yaml: |
  - conditions:
    - get_toy == 'yes'
    max_value: 2
    namespace: toystore-app
    seconds: 30
    variables: []
```

