### PR TITLE
DO NOT MERGE: v0.4.0 with limitador-server:v1.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.0
+VERSION ?= 0.4.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -35,12 +35,12 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/limitador-operator:latest
+    containerImage: quay.io/kuadrant/limitador-operator:v0.4.0
     operators.operatorframework.io/builder: operator-sdk-v1.22.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/limitador-operator
     support: kuadrant
-  name: limitador-operator.v0.0.0
+  name: limitador-operator.v0.4.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -141,8 +141,8 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_LIMITADOR
-                  value: quay.io/kuadrant/limitador:latest
-                image: quay.io/kuadrant/limitador-operator:latest
+                  value: quay.io/kuadrant/limitador:v1.0.0
+                image: quay.io/kuadrant/limitador-operator:v0.4.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -227,6 +227,7 @@ spec:
     name: Red Hat
     url: https://github.com/Kuadrant/limitador-operator
   relatedImages:
-  - image: quay.io/kuadrant/limitador:latest
+  - image: quay.io/kuadrant/limitador:v1.0.0
     name: limitador
-  version: 0.0.0
+  replaces: limitador-operator.v0.3.0
+  version: 0.4.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -14,4 +14,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kuadrant/limitador-operator
-  newTag: latest
+  newTag: v0.4.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,7 +31,7 @@ spec:
         - --leader-elect
         env:
         - name: RELATED_IMAGE_LIMITADOR
-          value: "quay.io/kuadrant/limitador:latest"
+          value: "quay.io/kuadrant/limitador:v1.0.0"
         image: controller:latest
         name: manager
         securityContext:

--- a/config/manifests/bases/limitador-operator.clusterserviceversion.template.yaml
+++ b/config/manifests/bases/limitador-operator.clusterserviceversion.template.yaml
@@ -54,3 +54,4 @@ spec:
     name: Red Hat
     url: https://github.com/Kuadrant/limitador-operator
   version: ${BUNDLE_VERSION}
+  replaces: limitador-operator.v0.3.0

--- a/config/manifests/bases/limitador-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/limitador-operator.clusterserviceversion.yaml
@@ -5,12 +5,12 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/limitador-operator:latest
+    containerImage: quay.io/kuadrant/limitador-operator:v0.4.0
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/limitador-operator
     support: kuadrant
-  name: limitador-operator.v0.0.0
+  name: limitador-operator.v0.4.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -53,4 +53,5 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/limitador-operator
-  version: 0.0.0
+  version: 0.4.0
+  replaces: limitador-operator.v0.3.0

--- a/pkg/limitador/image.go
+++ b/pkg/limitador/image.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	defaultImageVersion = fmt.Sprintf("%s:%s", LimitadorRepository, "latest")
+	defaultImageVersion = fmt.Sprintf("%s:%s", LimitadorRepository, "v1.0.0")
 )
 
 func GetLimitadorImageVersion() string {

--- a/pkg/limitador/image_test.go
+++ b/pkg/limitador/image_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestLimitadorDefaulImage(t *testing.T) {
-	assert.Equal(t, GetLimitadorImageVersion(), "quay.io/kuadrant/limitador:latest")
+	assert.Equal(t, GetLimitadorImageVersion(), "quay.io/kuadrant/limitador:v1.0.0")
 }


### PR DESCRIPTION
@didierofrivia Care to review if I forgot something? Had to fight the `make bundle` for a bit, … 
Is anything missing? Thinking I might be changing too much? Like the default (and the test)… but I feel like we should default to v1.0.0 of limitador _always_… 

### This branch would then become the tag and be deleted.

### Diff 

Diff against limitador operator bundle [v0.3.0](https://github.com/redhat-openshift-ecosystem/community-operators-prod/tree/main/operators/limitador-operator/0.3.0)

<details>

- [X] `tests/scorecard/config.yaml`: no changes
- [X] `metadata/annotations.yaml`: one openshift annotation. Decided to not include for now.
```diff
diff bundle/metadata/annotations.yaml 0.3.0/metadata/annotations.yaml 
11d10
< 
14a14,16
> 
>   # OpenShift annotations.
>   com.redhat.openshift.versions: "v4.9"
```
- [X] Limitador CRD `manifests/limitador.kuadrant.io_limitadors.yaml`: new changes in v0.4.0, i.e. the redis storage.
```diff
bundle/manifests/limitador.kuadrant.io_limitadors.yaml 0.3.0/manifests/limitador.kuadrant.io_limitadors.yaml 
80,235d79
<               storage:
<                 description: Storage contains the options for Limitador counters database
<                   or in-memory data storage
<                 properties:
<                   redis:
<                     properties:
<                       configSecretRef:
<                         description: 'ObjectReference contains enough information
<                           to let you inspect or modify the referred object. --- New
<                           uses of this type are discouraged because of difficulty
<                           describing its usage when embedded in APIs.  1. Ignored
...
```

- [X] `manifests/limitador-operator-manager-config_v1_configmap.yaml`: no changes
- [X] `manifests/limitador-operator-controller-manager-metrics-service_v1_service.yaml`: no changes
- [X] `manifests/limitador-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml`: no changes
- [X] `manifests/limitador-operator.clusterserviceversion.yaml`
```diff
diff 0.3.0/manifests/limitador-operator.clusterserviceversion.yaml bundle/manifests/limitador-operator.clusterserviceversion.yaml
17c17
<                   "get-toy == yes"
---
>                   "get_toy == 'yes'"
38,39c38
<     containerImage: quay.io/kuadrant/limitador-operator:v0.3.0
<     repository: https://github.com/Kuadrant/limitador-operator
---
>     containerImage: quay.io/kuadrant/limitador-operator:v0.4.0
42c41,43
<   name: limitador-operator.v0.3.0
---
>     repository: https://github.com/Kuadrant/limitador-operator
>     support: kuadrant
>   name: limitador-operator.v0.4.0
51,53c52,53
<       displayName: Limitador
<       description: Defines the Limitador Instance settings and its rate limits objects
<   description: The Limitador Operator manages the lifecycle of Limitador instances
---
>   description: The Limitador operator installs and maintains limitador instances as
>     well as rate limit objects.
55d54
<   minKubeVersion: "1.22.7"
57,58c56,57
<   - base64data: "iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAIAAAAiOjnJAAAHCklEQVR4nOzc72tWdQPH8e+tm/ecXGNO77mb3beZLgtkDxpCgT4IBBFqJT1YRqFS5oMS/BG5ioqhUc3IFKwHpqHSg9qDsCwIQeiBQoEotISyzcwa6bI5Nlyms8X4Lp1u1zzXub6f8/2ea+/XH3DO58GbXeec69opGhgYMIBrE3wPQGEiLEgQFiQICxKEBQnCggRhQYKwIEFYkCAsSBAWJAgLEoQFCcKCBGFBgrAgQViQICxIEBYkCAsShAUJwoIEYUGCsCBBWJAgLEgQFiQICxKEBQnCggRhQYKwIEFYkCAsSBAWJAgLEoQFCcKCBGFBgrAgQViQICxIEBYkCAsShAUJwoIEYUGCsCBR5HtAJI89uqytvT2fI2zetHnxkiXuFgn1d3eead44s3FLUXml7y3xpSOstvb24998m88Rurq63M0R6u/uPPlkw6VjZy+dbJi7uyW9bfFRGJBrVRljLh07++Mrz/heFB9hhWJ4VVbvgdZTL6z0Oio+wgrCyKqs7g+/+mX7855G5YWw/MtWldW5bf/5lh2Jj8oXYXk2dlVWR/POvtbDCY5ygLB8ilKVMeZq1+X2Dev7uzuT2uUAYXkTsSrrSltv+/o0XcgTlh85VWVd/PLUufdfU45yibA8iFGV1bF5X1outggraX2th+NVZZ1uesn1IgnCSlRf6+EfVj4duyr7RD4VT7YIKzm2qqtdl/M8Tue2/X/+dMLRKBXCSoirqqzTTc85OY4OYSXBbVX2DrH7iw9cHU2BsOScV2X9/NZ2twd0i7C0RFXZR6Yhf4dIWEK6qqyO5p3Bfs9DWCrqqux3iGf3btUdPx+EJZFAVdaFzw6pTxEPYbmXWFUhX2kRlmNJVmX9+t7exM4VHWG5lHxV9o9Wz5EDSZ4xCsJyxktV1rmP9iV/0rERlhseq7L/zxPacwfCcsBvVdbvH+/yePaRCCtfIVQ1GNbnB/0OuAlh5SWQquzvtIL6LQ1hxRdOVVb3oU98T7iOsGIKrarQPg0JK44Aq7KfhuHcGxJWzsKsyuo+2OJ7whDCyk3IVRljeo4f9T1hCGHl4HzLju8eXBVsVcaYi0dDuTEkrKjOt+w40xji7wiGu9LWG8hlFmFFkoqqrL4TX/ueYAgrkhRVNXiZdfSI7wmGsG4tXVUZY/7I7/XSrhDWWFJX1eBlVsdvvicYwhpLGquyj0l9TzCElVVKq7JCeNURYY0i1VUZY/p7LvieQFgjpL2qwev371t9TyCsGxVAVYPX7709vicQ1jCFUVUgCGtIIVUVwqMswjIFVpUx5q/ei74nEFbBVRWI8R4WVYmM67CoSmdchwWdcR3W9IY1M5vX+F5RmMZ1WLSlM97Doi0RwjKF19aEzBTfEwjrH4XU1uQ5c3xPIKxhCqkt7wjrBoXRVnGmzPcEwhqhANqafGet7wmENZq0t1VUNtX3BMLKItVtldYu9D2BsLJLaVsldVW+JxjCuoU0tlVc/R/fEwxh3Vrq2grhIRZhRZKutsrmL/A9wRBWVClqq3TePb4nGMLKQSraKq7JFJVX+l5hCCs30xvW3PXprokVk3wPyWrK/Hm+JwwhrNyU1i68Y8+7wbZVdvd83xOGEFbOQm6rfHGD7wlDCCuOMNsqqasK5AKLsOILsK1p9y/2PeE6woovtLbKFz3ke8J1hJWXcNoqqav6922h3BISlgOBtBXU5yBhuRFCW9MeXuXx7CMRlht+28rU14ZzP2gRljMe25rxyPLkTzo2wnLJS1vFNZmyBfVJnjEKwnIs+bb++9SKxM4VHWG5l2RbxTWZ6Q0h/uaCsCQSa2vqA4vUp4iHsFQSaGtixaSqFRt0x88HYQmp26puXB3aU4ZrCEtL11awV1cWYcmJ2vr/s2vdHtAtwkqC87am3De7fMnjro6mQFgJcdvWrKY3nRxHh7CS46qtynVLg/qFzKgIK1G2rXxer1BSV/W/tW84HSVBWEkrrV04d3dL7LZmNb3qepEEYXlQVF4Zr63ql5eH8IqiKAjLjxhtZeprZzzxonKUS4TlTU5tFddkbt/0jn6UM4TlU8S2JlZMmrP17WC/vRkVYXkWpa3qxtVpubS6hrD8G7utynVLQ/5OMBvCCkK2tsqX3ZuKp1YjEVYoRraVqa+d/foer6PiI6yADG+rpK4qXbeBNynyPSCSmrxf2FpRUeFoi5Zt60zzxpmNW9J1G3iTfw0MDPjegALERyEkCAsShAUJwoIEYUGCsCBBWJAgLEgQFiQICxKEBQnCggRhQYKwIEFYkCAsSBAWJAgLEoQFCcKCBGFBgrAgQViQICxIEBYkCAsShAUJwoIEYUGCsCBBWJAgLEgQFiQICxKEBQnCggRhQYKwIEFYkCAsSBAWJAgLEoQFCcKCBGFBgrAgQViQICxI/B0AAP//uLJ9vDn6iowAAAAASUVORK5CYII="
<     mediatype: "image/png"
---
>   - base64data: iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAIAAAAiOjnJAAAHCklEQVR4nOzc72tWdQPH8e+tm/ecXGNO77mb3beZLgtkDxpCgT4IBBFqJT1YRqFS5oMS/BG5ioqhUc3IFKwHpqHSg9qDsCwIQeiBQoEotISyzcwa6bI5Nlyms8X4Lp1u1zzXub6f8/2ea+/XH3DO58GbXeec69opGhgYMIBrE3wPQGEiLEgQFiQICxKEBQnCggRhQYKwIEFYkCAsSBAWJAgLEoQFCcKCBGFBgrAgQViQICxIEBYkCAsShAUJwoIEYUGCsCBBWJAgLEgQFiQICxKEBQnCggRhQYKwIEFYkCAsSBAWJAgLEoQFCcKCBGFBgrAgQViQICxIEBYkCAsShAUJwoIEYUGCsCBR5HtAJI89uqytvT2fI2zetHnxkiXuFgn1d3eead44s3FLUXml7y3xpSOstvb24998m88Rurq63M0R6u/uPPlkw6VjZy+dbJi7uyW9bfFRGJBrVRljLh07++Mrz/heFB9hhWJ4VVbvgdZTL6z0Oio+wgrCyKqs7g+/+mX7855G5YWw/MtWldW5bf/5lh2Jj8oXYXk2dlVWR/POvtbDCY5ygLB8ilKVMeZq1+X2Dev7uzuT2uUAYXkTsSrrSltv+/o0XcgTlh85VWVd/PLUufdfU45yibA8iFGV1bF5X1outggraX2th+NVZZ1uesn1IgnCSlRf6+EfVj4duyr7RD4VT7YIKzm2qqtdl/M8Tue2/X/+dMLRKBXCSoirqqzTTc85OY4OYSXBbVX2DrH7iw9cHU2BsOScV2X9/NZ2twd0i7C0RFXZR6Yhf4dIWEK6qqyO5p3Bfs9DWCrqqux3iGf3btUdPx+EJZFAVdaFzw6pTxEPYbmXWFUhX2kRlmNJVmX9+t7exM4VHWG5lHxV9o9Wz5EDSZ4xCsJyxktV1rmP9iV/0rERlhseq7L/zxPacwfCcsBvVdbvH+/yePaRCCtfIVQ1GNbnB/0OuAlh5SWQquzvtIL6LQ1hxRdOVVb3oU98T7iOsGIKrarQPg0JK44Aq7KfhuHcGxJWzsKsyuo+2OJ7whDCyk3IVRljeo4f9T1hCGHl4HzLju8eXBVsVcaYi0dDuTEkrKjOt+w40xji7wiGu9LWG8hlFmFFkoqqrL4TX/ueYAgrkhRVNXiZdfSI7wmGsG4tXVUZY/7I7/XSrhDWWFJX1eBlVsdvvicYwhpLGquyj0l9TzCElVVKq7JCeNURYY0i1VUZY/p7LvieQFgjpL2qwev371t9TyCsGxVAVYPX7709vicQ1jCFUVUgCGtIIVUVwqMswjIFVpUx5q/ei74nEFbBVRWI8R4WVYmM67CoSmdchwWdcR3W9IY1M5vX+F5RmMZ1WLSlM97Doi0RwjKF19aEzBTfEwjrH4XU1uQ5c3xPIKxhCqkt7wjrBoXRVnGmzPcEwhqhANqafGet7wmENZq0t1VUNtX3BMLKItVtldYu9D2BsLJLaVsldVW+JxjCuoU0tlVc/R/fEwxh3Vrq2grhIRZhRZKutsrmL/A9wRBWVClqq3TePb4nGMLKQSraKq7JFJVX+l5hCCs30xvW3PXprokVk3wPyWrK/Hm+JwwhrNyU1i68Y8+7wbZVdvd83xOGEFbOQm6rfHGD7wlDCCuOMNsqqasK5AKLsOILsK1p9y/2PeE6woovtLbKFz3ke8J1hJWXcNoqqav6922h3BISlgOBtBXU5yBhuRFCW9MeXuXx7CMRlht+28rU14ZzP2gRljMe25rxyPLkTzo2wnLJS1vFNZmyBfVJnjEKwnIs+bb++9SKxM4VHWG5l2RbxTWZ6Q0h/uaCsCQSa2vqA4vUp4iHsFQSaGtixaSqFRt0x88HYQmp26puXB3aU4ZrCEtL11awV1cWYcmJ2vr/s2vdHtAtwkqC87am3De7fMnjro6mQFgJcdvWrKY3nRxHh7CS46qtynVLg/qFzKgIK1G2rXxer1BSV/W/tW84HSVBWEkrrV04d3dL7LZmNb3qepEEYXlQVF4Zr63ql5eH8IqiKAjLjxhtZeprZzzxonKUS4TlTU5tFddkbt/0jn6UM4TlU8S2JlZMmrP17WC/vRkVYXkWpa3qxtVpubS6hrD8G7utynVLQ/5OMBvCCkK2tsqX3ZuKp1YjEVYoRraVqa+d/foer6PiI6yADG+rpK4qXbeBNynyPSCSmrxf2FpRUeFoi5Zt60zzxpmNW9J1G3iTfw0MDPjegALERyEkCAsShAUJwoIEYUGCsCBBWJAgLEgQFiQICxKEBQnCggRhQYKwIEFYkCAsSBAWJAgLEoQFCcKCBGFBgrAgQViQICxIEBYkCAsShAUJwoIEYUGCsCBBWJAgLEgQFiQICxKEBQnCggRhQYKwIEFYkCAsSBAWJAgLEoQFCcKCBGFBgrAgQViQICxI/B0AAP//uLJ9vDn6iowAAAAASUVORK5CYII=
>     mediatype: image/png
66a66
>           - secrets
143c143,146
<                 image: quay.io/kuadrant/limitador-operator:v0.3.0
---
>                 env:
>                 - name: RELATED_IMAGE_LIMITADOR
>                   value: quay.io/kuadrant/limitador:v1.0.0
>                 image: quay.io/kuadrant/limitador-operator:v0.4.0
162,163c165,166
<                     cpu: 100m
<                     memory: 30Mi
---
>                     cpu: 200m
>                     memory: 300Mi
165,166c168,169
<                     cpu: 100m
<                     memory: 20Mi
---
>                     cpu: 200m
>                     memory: 200Mi
211,212c214,217
<   - name: Kuadrant
<     url: https://kuadrant.io/
---
>   - name: Limitador Operator
>     url: https://github.com/Kuadrant/limitador-operator
>   - name: Kuadrant Docs
>     url: https://kuadrant.io
215c220,222
<     name: eguzki
---
>     name: Eguzki Astiz Lezaun
>   - email: asnaps@redhat.com
>     name: Alex Snaps
217c224
<     name: dd
---
>     name: Didier Di Cesare
218a226
>   minKubeVersion: 1.8.0
222c230,233
<   version: 0.3.0
---
>   relatedImages:
>   - image: quay.io/kuadrant/limitador:v1.0.0
>     name: limitador
>   version: 0.4.0
```

</details>