### PR TITLE
fix redis-cached deployment when no options are set

### DIFF
--- a/api/v1alpha1/limitador_types.go
+++ b/api/v1alpha1/limitador_types.go
@@ -142,30 +142,30 @@ func (s *Storage) SecretRef() *corev1.ObjectReference {
 
 func (s *Storage) Config(url string) []string {
 	if s.Redis != nil {
-		return []string{
-			string(StorageTypeRedis),
-			url,
-		}
-	} else if s.RedisCached != nil {
-		params := []string{
-			string(StorageTypeRedisCached),
-			url,
-		}
-		options := reflect.ValueOf(*s.RedisCached.Options)
-		typesOf := options.Type()
-		for i := 0; i < options.NumField(); i++ {
-			if !options.Field(i).IsNil() {
-				var value interface{} = options.Field(i).Elem()
-				params = append(
-					params,
-					fmt.Sprintf(
-						"--%s %d",
-						helpers.ToKebabCase(typesOf.Field(i).Name),
-						value))
+		return []string{string(StorageTypeRedis), url}
+	}
+
+	if s.RedisCached != nil {
+		params := []string{string(StorageTypeRedisCached), url}
+
+		if s.RedisCached.Options != nil {
+			options := reflect.ValueOf(*s.RedisCached.Options)
+			typesOf := options.Type()
+			for i := 0; i < options.NumField(); i++ {
+				if !options.Field(i).IsNil() {
+					var value interface{} = options.Field(i).Elem()
+					params = append(
+						params,
+						fmt.Sprintf(
+							"--%s %d",
+							helpers.ToKebabCase(typesOf.Field(i).Name),
+							value))
+				}
 			}
 		}
 		return params
 	}
+
 	return []string{string(StorageTypeInMemory)}
 }
 


### PR DESCRIPTION
###  what

Fix redis-cached deployment when no options are set.

It was panic-ing when the spec was

```yaml
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador
spec:
  storage:
    redis-cached:
      configSecretRef:
        name: redisconfig
```

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1381d23]

goroutine 312 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:118 +0x1f4
panic({0x14f07c0, 0x2373ad0})
	/usr/local/go/src/runtime/panic.go:838 +0x207
github.com/kuadrant/limitador-operator/api/v1alpha1.(*Storage).Config(0xc00015c3d0, {0xc000412240, 0x13})
	/workspace/api/v1alpha1/limitador_types.go:154 +0xc3
github.com/kuadrant/limitador-operator/pkg/limitador.storageConfig(...)
	/workspace/pkg/limitador/k8s_objects.go:198
github.com/kuadrant/limitador-operator/pkg/limitador.deploymentContainerCommand(0xc00015c3d0, 0xc000438b40)
	/workspace/pkg/limitador/k8s_objects.go:191 +0x166
github.com/kuadrant/limitador-operator/pkg/limitador.Deployment(0xc0002dc480, 0x23c7b68?)
	/workspace/pkg/limitador/k8s_objects.go:92 +0x259
github.com/kuadrant/limitador-operator/controllers.(*LimitadorReconciler).reconcileDeployment(0xc000712068, {0x18ecdb8, 0xc0002c0300}, 0xc0002dc480)
	/workspace/controllers/limitador_controller.go:149 +0x27e
github.com/kuadrant/limitador-operator/controllers.(*LimitadorReconciler).reconcileSpec(0x18ecdb8?, {0x18ecdb8, 0xc0002c0300}, 0xc0006158e0?)
	/workspace/controllers/limitador_controller.go:111 +0x4f
github.com/kuadrant/limitador-operator/controllers.(*LimitadorReconciler).Reconcile(0xc000712068, {0x18ecdb8, 0xc0002c0240}, {{{0xc0006158e0, 0xf}, {0xc0006158d6, 0x9}}})
	/workspace/controllers/limitador_controller.go:81 +0x3fb
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x18ecd10?, {0x18ecdb8?, 0xc0002c0240?}, {{{0xc0006158e0?, 0x15f6e20?}, {0xc0006158d6?, 0x4041f4?}}})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:121 +0xc8
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0000f5e00, {0x18ecd10, 0xc000308800}, {0x1541ba0?, 0xc00047a8a0?})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:320 +0x33c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0000f5e00, {0x18ecd10, 0xc000308800})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:273 +0x1d9
```

### Verification steps

* setup env
```
make local-env-setup
make run
```
* Deploy limitador with redis-cached **with no options**
```yaml
k apply -f - <<EOF
---
apiVersion: v1
kind: Secret
metadata:
  name: redisconfig
stringData:
  URL: redis://127.0.0.1/a # Redis URL of its running instance
type: Opaque
---
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador
spec:
  storage:
    redis-cached:
      configSecretRef:
        name: redisconfig
EOF
```

The controller should not panic. 

* The deployment should not have any extra command line args
```yaml
❯ k get deployment limitador -o jsonpath='{.spec.template.spec.containers[0].command}' | yq e -P
- limitador-server
- /home/limitador/etc/limitador-config.yaml
- redis_cached
- redis://127.0.0.1/a
```

```