### PR TITLE
fix Makefile version is semantic check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+# Setting SHELL to bash allows bash commands to be executed by recipes.
+# This is a requirement for 'setup-envtest.sh' in the test target.
+# Options are set to exit when a recipe line exits non-zero or a piped command fails.
+SHELL = /usr/bin/env bash -o pipefail
+.SHELLFLAGS = -ec
+
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 
@@ -51,20 +57,15 @@ ifeq ($(shell uname -sm),Darwin arm64)
 	ARCH_PARAM = --arch=amd64
 endif
 
-DEFAULT_IMAGE_TAG = latest
-
 # Semantic versioning (i.e. Major.Minor.Patch)
-is_semantic_version = $(shell [[ $(1) =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$$ ]] && echo "true")
+VERSION_IS_SEMANTIC = $(shell [[ $(VERSION) =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$$ ]] && echo "true")
 
 # BUNDLE_VERSION defines the version for the limitador-operator bundle.
 # If the version is not semantic, will use the default one
-bundle_is_semantic := $(call is_semantic_version,$(VERSION))
-ifdef bundle_is_semantic
+ifeq ($(VERSION_IS_SEMANTIC),true)
 BUNDLE_VERSION = $(VERSION)
-IMAGE_TAG = v$(VERSION)
 else
 BUNDLE_VERSION = 0.0.0
-IMAGE_TAG ?= $(DEFAULT_IMAGE_TAG)
 endif
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
@@ -84,11 +85,6 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-# Setting SHELL to bash allows bash commands to be executed by recipes.
-# This is a requirement for 'setup-envtest.sh' in the test target.
-# Options are set to exit when a recipe line exits non-zero or a piped command fails.
-SHELL = /usr/bin/env bash -o pipefail
-.SHELLFLAGS = -ec
 
 all: build
 


### PR DESCRIPTION
### what

First I fixed the "is_version_semantic" shell script which was never working in bash.  

Then I realized that the bundle changed with image pointing to ''v0.0.0". Then, I removed setting IMAGE_TAG based on "is_version_semantic". 

### verification steps
* setting version to "1.2.3"
```
$ make bundle VERSION=1.2.3
/home/eguzki/git/kuadrant/limitador-operator2/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/home/eguzki/git/kuadrant/limitador-operator2/bin/operator-sdk generate kustomize manifests -q
WARN[0000] Skipping definitions parsing for API {}: Go type not found 
# Set desired operator image
cd config/manager && /home/eguzki/git/kuadrant/limitador-operator2/bin/kustomize edit set image controller=quay.io/kuadrant/limitador-operator:v1.2.3
# Update CSV
V="limitador-operator.v1.2.3" /home/eguzki/git/kuadrant/limitador-operator2/bin/yq eval '.metadata.name = strenv(V)' -i config/manifests/bases/limitador-operator.clusterserviceversion.yaml
....
```

from the logs we can see the bundle version is `limitador-operator.v1.2.3` and the image references to `quay.io/kuadrant/limitador-operator:v1.2.3`

* setting version to something "not X.Y.Z", 
```
$ make bundle VERSION=unknown
/home/eguzki/git/kuadrant/limitador-operator2/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/home/eguzki/git/kuadrant/limitador-operator2/bin/operator-sdk generate kustomize manifests -q
WARN[0000] Skipping definitions parsing for API {}: Go type not found 
# Set desired operator image
cd config/manager && /home/eguzki/git/kuadrant/limitador-operator2/bin/kustomize edit set image controller=quay.io/kuadrant/limitador-operator:vunknown
# Update CSV
V="limitador-operator.v0.0.0" /home/eguzki/git/kuadrant/limitador-operator2/bin/yq eval '.metadata.name = strenv(V)' -i config/manifests/bases/limitador-operator.clusterserviceversion.yaml
....
```
from the logs we can see the bundle version is `limitador-operator.v0.0.0` and the image references to `quay.io/kuadrant/limitador-operator:vunknown`

PS: Semantic versioning is not having version format X.Y.Z. Semantic versioning is what you can imply when upgrading major version, minor version or patch version.