### PR TITLE
Add Rate limit headers to the Limitador CRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Operator to manage [Limitador](https://github.com/Kuadrant/limitador) deploy
 
 ### Limitador CRD
 
-[Limitador v1alpha1 API reference](api/v1alpha1/limitador_types.go)
+[Limitador v1alpha1 API reference](/api/v1alpha1/limitador_types.go)
 
 Example:
 
@@ -35,6 +35,12 @@ spec:
       seconds: 30
       variables: []
 ```
+
+## Features
+
+* [Storage Options](/doc/storage.md)
+* [Rate Limit Headers](/doc/rate-limit-headers.md)
+* [Logging](/doc/logging.md)
 
 ## Contributing
 

--- a/api/v1alpha1/limitador_types.go
+++ b/api/v1alpha1/limitador_types.go
@@ -57,6 +57,9 @@ type LimitadorSpec struct {
 	Storage *Storage `json:"storage,omitempty"`
 
 	// +optional
+	RateLimitHeaders *RateLimitHeadersType `json:"rateLimitHeaders,omitempty"`
+
+	// +optional
 	Limits []RateLimit `json:"limits,omitempty"`
 }
 
@@ -108,6 +111,10 @@ type LimitadorList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Limitador `json:"items"`
 }
+
+// RateLimitHeadersType defines the valid options for the --rate-limit-headers arg
+// +kubebuilder:validation:Enum=NONE;DRAFT_VERSION_03
+type RateLimitHeadersType string
 
 // StorageType defines the valid options for storage
 // +kubebuilder:validation:Enum=memory;redis;redis_cached

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -125,6 +125,11 @@ func (in *LimitadorSpec) DeepCopyInto(out *LimitadorSpec) {
 		*out = new(Storage)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.RateLimitHeaders != nil {
+		in, out := &in.RateLimitHeaders, &out.RateLimitHeaders
+		*out = new(RateLimitHeadersType)
+		**out = **in
+	}
 	if in.Limits != nil {
 		in, out := &in.Limits, &out.Limits
 		*out = make([]RateLimit, len(*in))

--- a/bundle/manifests/limitador.kuadrant.io_limitadors.yaml
+++ b/bundle/manifests/limitador.kuadrant.io_limitadors.yaml
@@ -75,6 +75,13 @@ spec:
                         type: integer
                     type: object
                 type: object
+              rateLimitHeaders:
+                description: RateLimitHeadersType defines the valid options for the
+                  --rate-limit-headers arg
+                enum:
+                - NONE
+                - DRAFT_VERSION_03
+                type: string
               replicas:
                 type: integer
               storage:

--- a/config/crd/bases/limitador.kuadrant.io_limitadors.yaml
+++ b/config/crd/bases/limitador.kuadrant.io_limitadors.yaml
@@ -76,6 +76,13 @@ spec:
                         type: integer
                     type: object
                 type: object
+              rateLimitHeaders:
+                description: RateLimitHeadersType defines the valid options for the
+                  --rate-limit-headers arg
+                enum:
+                - NONE
+                - DRAFT_VERSION_03
+                type: string
               replicas:
                 type: integer
               storage:

--- a/controllers/limitador_controller.go
+++ b/controllers/limitador_controller.go
@@ -144,6 +144,7 @@ func (r *LimitadorReconciler) reconcileDeployment(ctx context.Context, limitador
 
 	deploymentMutators = append(deploymentMutators,
 		reconcilers.DeploymentImageMutator,
+		reconcilers.DeploymentCommandMutator,
 	)
 
 	deployment := limitador.Deployment(limitadorObj, storageConfigSecret)

--- a/doc/rate-limit-headers.md
+++ b/doc/rate-limit-headers.md
@@ -1,0 +1,20 @@
+# Rate Limit Headers
+
+It enables RateLimit Header Fields for HTTP as specified in
+[Rate Limit Headers Draft](https://datatracker.ietf.org/doc/id/draft-polli-ratelimit-headers-03.html)
+
+```yaml
+apiVersion: limitador.kuadrant.io/v1alpha1
+kind: Limitador
+metadata:
+  name: limitador-sample
+spec:
+  rateLimitHeaders: DRAFT_VERSION_03
+```
+
+Current valid values are:
+* *DRAFT_VERSION_03* (ref: https://datatracker.ietf.org/doc/id/draft-polli-ratelimit-headers-03.html)
+* *NONE*
+
+By default, when `spec.rateLimitHeaders` is *null*, `--rate-limit-headers` command line arg is not
+included in the limitador's deployment.

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -6,7 +6,7 @@ In order to configure a Redis data structure store, currently there are 2 altern
 * Redis
 * Redis Cached
 
-For any of those, one should store the URL of the Redis service, inside a K8s opaque 
+For any of those, one should store the URL of the Redis service, inside a K8s opaque
 [Secret](https://kubernetes.io/docs/concepts/configuration/secret/).
 
 ```yaml
@@ -51,7 +51,7 @@ spec:
 | ttl          | TTL for cached counters in milliseconds [default: 5000]           |
 | ratio        | Ratio to apply to the TTL from Redis on cached counters [default: |
 | flush-period | Flushing period for counters in milliseconds [default: 1000]      |
- | max-cached   | Maximum amount of counters cached [default: 10000]                |
+| max-cached   | Maximum amount of counters cached [default: 10000]                |
 
 
 ```yaml
@@ -66,8 +66,8 @@ spec:
         name: redisconfig
         namespace: default # optional
      options: # Every option is optional
-        ttl: 1000      
-       
+        ttl: 1000
+
   limits:
     - conditions: ["get_toy == 'yes'"]
       max_value: 2

--- a/pkg/reconcilers/deployment.go
+++ b/pkg/reconcilers/deployment.go
@@ -2,6 +2,7 @@ package reconcilers
 
 import (
 	"fmt"
+	"reflect"
 
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,6 +60,17 @@ func DeploymentImageMutator(desired, existing *appsv1.Deployment) bool {
 
 	if existing.Spec.Template.Spec.Containers[0].Image != desired.Spec.Template.Spec.Containers[0].Image {
 		existing.Spec.Template.Spec.Containers[0].Image = desired.Spec.Template.Spec.Containers[0].Image
+		update = true
+	}
+
+	return update
+}
+
+func DeploymentCommandMutator(desired, existing *appsv1.Deployment) bool {
+	update := false
+
+	if !reflect.DeepEqual(existing.Spec.Template.Spec.Containers[0].Command, desired.Spec.Template.Spec.Containers[0].Command) {
+		existing.Spec.Template.Spec.Containers[0].Command = desired.Spec.Template.Spec.Containers[0].Command
 		update = true
 	}
 


### PR DESCRIPTION
### What

Exposes the rate limit headers feature implemented in limitador https://github.com/Kuadrant/limitador/pull/158/files

```yaml
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador-sample
spec:
  rateLimitHeaders: DRAFT_VERSION_03
```
Current valid values are: 
* *DRAFT_VERSION_03* (ref: https://datatracker.ietf.org/doc/id/draft-polli-ratelimit-headers-03.html)
* *NONE*

By default, i.e. with the simplest limitador CR, `--rate-limit-headers` command line arg is not included in the limitador's deployment.

Reconciliation of `spec.rateLimitHeaders`, meaning that changing (patching) that field `spec.rateLimitHeaders` after being created will trigger rolling out of the limitador deployment.

TODO
- [x] Doc

### Verification steps

#### Default Behavior

* Dev setup
```
make local-setup
```

* Limitador CR without rate limit header spec

```yaml
k apply -f - <<EOF
---
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador-sample
spec: {}
EOF
```

* Wait for deployment to be ready
```
❯ k wait --for=condition=ready limitador/limitador-sample --timeout=-1s
limitador.limitador.kuadrant.io/limitador-sample condition met
```
* Verify command does not have limit headers arguments
```yaml
> kubectl get $(kubectl get pod -l app=limitador -o name) -o jsonpath='{.spec.containers[0].command}'  | yq e -P
- limitador-server
- /home/limitador/etc/limitador-config.yaml
- memory
```

#### Rate Limit headers set

* Dev setup
```
make local-setup
```
* Limitador CR with rate limit header spec

```yaml
k apply -f - <<EOF
---
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador-sample
spec: 
  rateLimitHeaders: DRAFT_VERSION_03
EOF
```
* Wait for deployment to be ready
```
❯ k wait --for=condition=ready limitador/limitador-sample --timeout=-1s
limitador.limitador.kuadrant.io/limitador-sample condition met
```
* Verify command having limit headers arguments
```yaml
> kubectl get $(kubectl get pod -l app=limitador -o name) -o jsonpath='{.spec.containers[0].command}'  | yq e -P
- limitador-server
- --rate-limit-headers
- DRAFT_VERSION_03
- /home/limitador/etc/limitador-config.yaml
- memory
```
* Patch limitador CR to remove the rate limits header field
```
❯ k patch limitador limitador-sample --type=json -p="[{'op': 'remove', 'path': '/spec/rateLimitHeaders'}]"
limitador.limitador.kuadrant.io/limitador-sample patched
```
* Wait for deployment to be ready
```
❯ k wait --for=condition=ready limitador/limitador-sample --timeout=-1s
limitador.limitador.kuadrant.io/limitador-sample condition met
```
* Verify command does not have limit headers arguments
```yaml
> kubectl get $(kubectl get pod -l app=limitador -o name) -o jsonpath='{.spec.containers[0].command}'  | yq e -P
- limitador-server
- /home/limitador/etc/limitador-config.yaml
- memory
```

