### PR TITLE
Limitador version in bundle

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -11,6 +11,10 @@ on:
         description: Operator tag
         default: latest
         type: string
+      limitadorVersion:
+        description: Limitador version
+        default: latest
+        type: string
   workflow_dispatch:
     inputs:
       operatorVersion:
@@ -19,6 +23,10 @@ on:
         type: string
       operatorTag:
         description: Operator tag
+        default: latest
+        type: string
+      limitadorVersion:
+        description: Limitador version
         default: latest
         type: string
 
@@ -83,7 +91,7 @@ jobs:
         id: make-bundle
         run: |
           make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} \
-            VERSION=${{ env.VERSION }} IMAGE_TAG=${{ inputs.operatorTag }}
+            VERSION=${{ env.VERSION }} IMAGE_TAG=${{ inputs.operatorTag }} LIMITADOR_VERSION=${{ inputs.limitadorVersion }}
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2
@@ -121,7 +129,7 @@ jobs:
       - name: Generate Catalog Content
         run: |
           make catalog REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} \
-            VERSION=${{ env.VERSION }} IMAGE_TAG=${{ inputs.operatorTag }}
+            VERSION=${{ env.VERSION }} IMAGE_TAG=${{ inputs.operatorTag }} LIMITADOR_VERSION=${{ inputs.limitadorVersion }}
       - name: Install qemu dependency
         run: |
           sudo apt-get update

--- a/.github/workflows/build-images-scheduled.yaml
+++ b/.github/workflows/build-images-scheduled.yaml
@@ -1,0 +1,15 @@
+name: Schedule build with latest image SHA versions
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  workflow-build:
+    name: Calls build-images-base workflow
+    uses: ./.github/workflows/build-images-base.yaml
+    secrets: inherit
+    with:
+      operatorVersion: ${{ github.sha }}
+      operatorTag: ${{ github.sha }}
+      limitadorVersion: ${{ vars.LIMITADOR_SHA }}

--- a/doc/development.md
+++ b/doc/development.md
@@ -92,15 +92,18 @@ If you want to deploy (using OLM) a custom limitador operator, you need to build
 
 The `make bundle` target accepts the following variables:
 
-| **Makefile Variable** | **Description** | **Default value** |
-| --- | --- | --- |
-| `IMG` | Operator image URL | `quay.io/kuadrant/limitador-operator:latest` |
-| `VERSION` | Bundle version | `0.0.0` |
+| **Makefile Variable**     | **Description**      | **Default value**                            | **Notes**                                                                |
+|---------------------------|----------------------|----------------------------------------------|--------------------------------------------------------------------------|
+| `IMG`                     | Operator image URL   | `quay.io/kuadrant/limitador-operator:latest` |                                                                          |
+| `VERSION`                 | Bundle version       | `0.0.0`                                      |                                                                          |
+| `RELATED_IMAGE_LIMITADOR` | Limitador bundle URL | `quay.io/kuadrant/limitador:latest`          | `LIMITADOR_VERSION` var could be use to build this URL providing the tag |
 
 * Build the bundle manifests
 
 ```bash
-make bundle [IMG=quay.io/kuadrant/limitador-operator:latest] [VERSION=0.0.0]
+make bundle [IMG=quay.io/kuadrant/limitador-operator:latest] \
+            [VERSION=0.0.0] \
+            [RELATED_IMAGE_LIMITADOR=quay.io/kuadrant/limitador:latest]
 ```
 
 * Build the bundle image from the manifests


### PR DESCRIPTION
This PR introduces the following changes:

1. Adds the version of limitador in the operator bundle
2. Modifies the Github workflow to build both catalog and bundle with the same limitador version
3. Introduces the scheduled build for sha images
4. Updates the documentation