### PR TITLE
kind: bump to v0.20.0 & pin image to kindest/node:v1.27.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ opm: $(OPM) ## Download opm locally if necessary.
 
 KIND = $(PROJECT_PATH)/bin/kind
 $(KIND):
-	$(call go-install-tool,$(KIND),sigs.k8s.io/kind@v0.11.1)
+	$(call go-install-tool,$(KIND),sigs.k8s.io/kind@v0.20.0)
 
 .PHONY: kind
 kind: $(KIND) ## Download kind locally if necessary.

--- a/doc/development.md
+++ b/doc/development.md
@@ -21,7 +21,7 @@
 ## Technology stack required for development
 
 * [operator-sdk] version v1.22.0
-* [kind] version v0.11.1
+* [kind] version v0.20.0
 * [git][git_tool]
 * [go] version 1.18+
 * [kubernetes] version v1.19+

--- a/utils/kind-cluster.yaml
+++ b/utils/kind-cluster.yaml
@@ -3,4 +3,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.22.7
+  image: kindest/node:v1.27.3


### PR DESCRIPTION
Similar to https://github.com/Kuadrant/kuadrant-operator/pull/209, bumping kind version to v0.20.0 and image to kindest/node:v1.27.3 to allow running `make local-setup` on Darwin arm64 using `cgroupv2` on docker