### PR TITLE
ignore: vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ testbin
 
 /catalog/limitador-operator-catalog
 /catalog/limitador-operator-catalog.Dockerfile
+
+# Vendor dependencies
+vendor


### PR DESCRIPTION
* Ignore vendor directory since it's not specifically committed anyhow. This prevents a contributor from accidently commiting it if generated by them