### PR TITLE
docs: minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ The Operator to manage [Limitador](https://github.com/Kuadrant/limitador) deploy
 
 ## CustomResourceDefinitions
 
-* [Limitador](#limitador), which defines a desired Limitador deployment.
+* [Limitador](#limitador-crd), which defines a desired Limitador deployment.
 
 ### Limitador CRD
 
-[Limitador v1alpha1 API reference](/api/v1alpha1/limitador_types.go)
+[Limitador v1alpha1 API reference](./api/v1alpha1/limitador_types.go)
 
 Example:
 
@@ -39,13 +39,13 @@ spec:
 
 ## Features
 
-* [Storage Options](/doc/storage.md)
-* [Rate Limit Headers](/doc/rate-limit-headers.md)
-* [Logging](/doc/logging.md)
+* [Storage Options](./doc/storage.md)
+* [Rate Limit Headers](./doc/rate-limit-headers.md)
+* [Logging](./doc/logging.md)
 
 ## Contributing
 
-The [Development guide](doc/development.md) describes how to build the operator and
+The [Development guide](./doc/development.md) describes how to build the operator and
 how to test your changes before submitting a patch or opening a PR.
 
 Join us on [kuadrant.slack.com](https://kuadrant.slack.com/)

--- a/doc/development.md
+++ b/doc/development.md
@@ -12,7 +12,7 @@
    * [Cleaning up](#cleaning-up)
    * [Run tests](#run-tests)
       * [Lint tests](#lint-tests)
-   * [(Un)Install Limitador CRD](#uninstall-limitador-crds)
+   * [(Un)Install Limitador CRD](#uninstall-limitador-crd)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
 
@@ -76,9 +76,9 @@ make install-olm
 
 Deploy the operator using OLM. The `make deploy-catalog` target accepts the following variables:
 
-| **Makefile Variable** | **Description** | **Default value** |
-| --- | --- | --- |
-| `CATALOG_IMG` | Catalog image URL | `quay.io/kuadrant/limitador-operator-catalog:latest` |
+| **Makefile Variable** | **Description**   | **Default value**                                    |
+|-----------------------|-------------------|------------------------------------------------------|
+| `CATALOG_IMG`         | Catalog image URL | `quay.io/kuadrant/limitador-operator-catalog:latest` |
 
 ```sh
 make deploy-catalog [CATALOG_IMG=quay.io/kuadrant/limitador-operator-catalog:latest]
@@ -108,9 +108,9 @@ make bundle [IMG=quay.io/kuadrant/limitador-operator:latest] \
 
 * Build the bundle image from the manifests
 
-| **Makefile Variable** | **Description** | **Default value** |
-| --- | --- | --- |
-| `BUNDLE_IMG` | Operator bundle image URL | `quay.io/kuadrant/limitador-operator-bundle:latest` |
+| **Makefile Variable** | **Description**           | **Default value**                                   |
+|-----------------------|---------------------------|-----------------------------------------------------|
+| `BUNDLE_IMG`          | Operator bundle image URL | `quay.io/kuadrant/limitador-operator-bundle:latest` |
 
 ```sh
 make bundle-build [BUNDLE_IMG=quay.io/kuadrant/limitador-operator-bundle:latest]
@@ -118,9 +118,9 @@ make bundle-build [BUNDLE_IMG=quay.io/kuadrant/limitador-operator-bundle:latest]
 
 * Push the bundle image to a registry
 
-| **Makefile Variable** | **Description** | **Default value** |
-| --- | --- | --- |
-| `BUNDLE_IMG` | Operator bundle image URL | `quay.io/kuadrant/limitador-operator-bundle:latest` |
+| **Makefile Variable** | **Description**           | **Default value**                                   |
+|-----------------------|---------------------------|-----------------------------------------------------|
+| `BUNDLE_IMG`          | Operator bundle image URL | `quay.io/kuadrant/limitador-operator-bundle:latest` |
 
 ```sh
 make bundle-push [BUNDLE_IMG=quay.io/kuadrant/limitador-operator-bundle:latest]
@@ -128,15 +128,15 @@ make bundle-push [BUNDLE_IMG=quay.io/kuadrant/limitador-operator-bundle:latest]
 
 ### Build custom catalog
 
-The catalog format will be [File-based Catalg](https://olm.operatorframework.io/docs/reference/file-based-catalogs/).
+The catalog format will be [File-based Catalog](https://olm.operatorframework.io/docs/reference/file-based-catalogs/).
 
 Make sure all the required bundles are pushed to the registry. It is required by the `opm` tool.
 
 The `make catalog` target accepts the following variables:
 
-| **Makefile Variable** | **Description** | **Default value** |
-| --- | --- | --- |
-| `BUNDLE_IMG` | Operator bundle image URL | `quay.io/kuadrant/limitador-operator-bundle:latest` |
+| **Makefile Variable** | **Description**           | **Default value**                                   |
+|-----------------------|---------------------------|-----------------------------------------------------|
+| `BUNDLE_IMG`          | Operator bundle image URL | `quay.io/kuadrant/limitador-operator-bundle:latest` |
 
 ```sh
 make catalog [BUNDLE_IMG=quay.io/kuadrant/limitador-operator-bundle:latest]
@@ -144,9 +144,9 @@ make catalog [BUNDLE_IMG=quay.io/kuadrant/limitador-operator-bundle:latest]
 
 * Build the catalog image from the manifests
 
-| **Makefile Variable** | **Description** | **Default value** |
-| --- | --- | --- |
-| `CATALOG_IMG` | Operator catalog image URL | `quay.io/kuadrant/limitador-operator-catalog:latest` |
+| **Makefile Variable** | **Description**            | **Default value**                                    |
+|-----------------------|----------------------------|------------------------------------------------------|
+| `CATALOG_IMG`         | Operator catalog image URL | `quay.io/kuadrant/limitador-operator-catalog:latest` |
 
 ```sh
 make catalog-build [CATALOG_IMG=quay.io/kuadrant/limitador-operator-catalog:latest]

--- a/doc/logging.md
+++ b/doc/logging.md
@@ -5,7 +5,7 @@ The limitador operator outputs 3 levels of log messages: (from lowest to highest
 2. `info` (default)
 3. `error`
 
-`info` logging is restricted to high-level information. Actions like creating, deleteing or updating kubernetes resources will be logged with reduced details about the corresponding objects, and without any further detailed logs of the steps in between, except for errors.
+`info` logging is restricted to high-level information. Actions like creating, deleting or updating kubernetes resources will be logged with reduced details about the corresponding objects, and without any further detailed logs of the steps in between, except for errors.
 
 Only `debug` logging will include processing details.
 

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -65,7 +65,7 @@ spec:
       configSecretRef: # The secret reference storing the URL for Redis
         name: redisconfig
         namespace: default # optional
-     options: # Every option is optional
+      options: # Every option is optional
         ttl: 1000
 
   limits:

--- a/pkg/limitador/image_test.go
+++ b/pkg/limitador/image_test.go
@@ -6,6 +6,6 @@ import (
 	"gotest.tools/assert"
 )
 
-func TestLimitadorDefaulImage(t *testing.T) {
+func TestLimitadorDefaultImage(t *testing.T) {
 	assert.Equal(t, GetLimitadorImageVersion(), "quay.io/kuadrant/limitador:latest")
 }


### PR DESCRIPTION
* Fix broken doc referecencs
* Use relative doc links for consistency
  * Also allows Goland IDE to find the docs in the rendered markdown 
* Fix typo
* General formatting fixes for yaml & tables 