### PR TITLE
Go1.19 & actions/checkout@v3 & actions/setup-go@v4

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install qemu dependency
         run: |
           sudo apt-get update
@@ -82,7 +82,7 @@ jobs:
           go-version: 1.19.x
         id: go
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install qemu dependency
         run: |
           sudo apt-get update
@@ -125,7 +125,7 @@ jobs:
           go-version: 1.19.x
         id: go
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Generate Catalog Content
         run: |
           make catalog REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} \

--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -76,10 +76,10 @@ jobs:
     name: Build Bundle
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
         id: go
       - name: Check out code
         uses: actions/checkout@v2
@@ -119,10 +119,10 @@ jobs:
     needs: [build, build-bundle]
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
         id: go
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.19.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19.x
         id: go
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.19.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19.x
         id: go

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.19.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19.x
         id: go
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.19.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19.x
         id: go
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.19.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19.x
         id: go
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.19.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19.x
         id: go
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.19.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19.x
         id: go

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
         id: go
       - uses: actions/checkout@v2
       - name: Run the tests
@@ -31,10 +31,10 @@ jobs:
     name: Verify manifests
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
         id: go
       - uses: actions/checkout@v2
       - name: Verify manifests
@@ -43,10 +43,10 @@ jobs:
     name: Verify bundle
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
         id: go
       - name: Check out code
         uses: actions/checkout@v2
@@ -57,10 +57,10 @@ jobs:
     name: Verify fmt
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
         id: go
       - name: Check out code
         uses: actions/checkout@v2
@@ -71,10 +71,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
         id: go
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: 1.19.x
         id: go
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run the tests
         run: make test
       - name: Upload coverage reports to Codecov
@@ -36,7 +36,7 @@ jobs:
         with:
           go-version: 1.19.x
         id: go
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Verify manifests
         run: make verify-manifests
   verify-bundle:
@@ -49,7 +49,7 @@ jobs:
           go-version: 1.19.x
         id: go
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run make verify-bundle
         run: |
           make verify-bundle
@@ -63,7 +63,7 @@ jobs:
           go-version: 1.19.x
         id: go
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run make verify-fmt
         run: |
           make verify-fmt
@@ -77,6 +77,6 @@ jobs:
           go-version: 1.19.x
         id: go
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Go Lint
         run: make run-lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.18 as builder
+FROM golang:1.19 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/doc/development.md
+++ b/doc/development.md
@@ -23,7 +23,7 @@
 * [operator-sdk] version v1.22.0
 * [kind] version v0.20.0
 * [git][git_tool]
-* [go] version 1.18+
+* [go] version 1.19+
 * [kubernetes] version v1.19+
 * [kubectl] version v1.19+
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/limitador-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-logr/logr v1.2.0


### PR DESCRIPTION
* Use go1.19 to align with most other kuadrant projects
* Use actions/checkout@v3 instead
* Use actions/setup-go@v4 instead

Closes: https://github.com/Kuadrant/limitador-operator/issues/84 https://github.com/Kuadrant/limitador-operator/issues/85