### PR TITLE
codecov: do not fail ci on error

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           flags: unit
           verbose: true
-          fail_ci_if_error: true
+          fail_ci_if_error: false
   verify-manifests:
     name: Verify manifests
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,7 @@ jobs:
           flags: unit
           verbose: true
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
   verify-manifests:
     name: Verify manifests
     runs-on: ubuntu-latest


### PR DESCRIPTION
* Prevent codecov from failing ci on error due to flakiness with codecov upload
* Use `CODECOV_TOKEN` for upload that should at least prevent upload issue when PRs come from branches from this repo