### PR TITLE
deployment CR reconcile of containers

### DIFF
--- a/controllers/limitador_controller.go
+++ b/controllers/limitador_controller.go
@@ -143,6 +143,7 @@ func (r *LimitadorReconciler) reconcileDeployment(ctx context.Context, limitador
 	}
 
 	deploymentMutators = append(deploymentMutators,
+		reconcilers.DeploymentContainerListMutator,
 		reconcilers.DeploymentImageMutator,
 		reconcilers.DeploymentCommandMutator,
 	)

--- a/pkg/reconcilers/deployment.go
+++ b/pkg/reconcilers/deployment.go
@@ -55,6 +55,17 @@ func DeploymentReplicasMutator(desired, existing *appsv1.Deployment) bool {
 	return update
 }
 
+func DeploymentContainerListMutator(desired, existing *appsv1.Deployment) bool {
+	update := false
+
+	if len(existing.Spec.Template.Spec.Containers) != len(desired.Spec.Template.Spec.Containers) {
+		existing.Spec.Template.Spec.Containers = desired.Spec.Template.Spec.Containers
+		update = true
+	}
+
+	return update
+}
+
 func DeploymentImageMutator(desired, existing *appsv1.Deployment) bool {
 	update := false
 

--- a/pkg/reconcilers/deployment_test.go
+++ b/pkg/reconcilers/deployment_test.go
@@ -1,0 +1,89 @@
+package reconcilers_test
+
+import (
+	"github.com/kuadrant/limitador-operator/pkg/reconcilers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Deployment", func() {
+	var desired *appsv1.Deployment
+
+	BeforeEach(func() {
+		desired = &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "sample",
+				Namespace: "test",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "expected",
+							},
+						},
+					},
+				},
+			},
+		}
+	})
+	Describe("DeploymentContainerListMutator()", func() {
+		It("Container image length is correct", func() {
+			existing := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sample",
+					Namespace: "test",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "expected",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			result := reconcilers.DeploymentContainerListMutator(desired, existing)
+
+			Expect(result).To(Equal(false))
+
+		})
+
+		It("Container spec has too many containers", func() {
+			existing := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sample",
+					Namespace: "test",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "expected",
+								},
+								{
+									Name: "unexpected",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			result := reconcilers.DeploymentContainerListMutator(desired, existing)
+
+			Expect(result).To(Equal(true))
+			Expect(len(existing.Spec.Template.Spec.Containers)).To(Equal(len(desired.Spec.Template.Spec.Containers)))
+
+		})
+	})
+})

--- a/pkg/reconcilers/suite_test.go
+++ b/pkg/reconcilers/suite_test.go
@@ -1,0 +1,13 @@
+package reconcilers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestReconcilers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Reconcilers Suite")
+}


### PR DESCRIPTION
Ensure that only containers that are managed by the limitador-operator can be added to the limitador deployment CR.

# Verification
* Run this branch
```sh
make local-setup
```
* Add a limitador deployment
```sh
echo "
   apiVersion: limitador.kuadrant.io/v1alpha1
   kind: Limitador
   metadata:
     name: limitador-sample
   spec:
     listener:
       http:
         port: 8080
       grpc:
         port: 8081
     limits:
       - conditions: ["get_toy == 'yes'"]
         max_value: 2
         namespace: toystore-app
         seconds: 30
         variables: []
   " | kubectl apply -f -
```
* **Check:** There should only be one container in the deployment spec
```sh
kubectl get deployment limitador-sample -o jsonpath='{.spec.template.spec.containers}' | jq 'length'
```
* Add new container to the deployment CR
```sh
kubectl patch deployment limitador-sample -n default --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/-", "value": {"name": "hello-sidecar", "image": "quay.io/podman/hello"}}]'
```
* **Expected:** The patch will be complete and kubectl will not return an error. But the operator will revert the changes to only have one container present.
```sh
kubectl get deployment limitador-sample -o jsonpath='{.spec.template.spec.containers}' | jq 'length'
``` 

Resolves  #90 