### PR TITLE
[workflow] Adding channels input for bundle creation

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -15,6 +15,10 @@ on:
         description: Limitador version
         default: latest
         type: string
+      channels:
+        description: Bundle and catalog channels, comma separated
+        default: preview
+        type: string
   workflow_dispatch:
     inputs:
       operatorVersion:
@@ -28,6 +32,10 @@ on:
       limitadorVersion:
         description: Limitador version
         default: latest
+        type: string
+      channels:
+        description: Bundle and catalog channels, comma separated
+        default: preview
         type: string
 
 env:
@@ -90,8 +98,13 @@ jobs:
       - name: Run make bundle
         id: make-bundle
         run: |
-          make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} \
-            VERSION=${{ env.VERSION }} IMAGE_TAG=${{ inputs.operatorTag }} LIMITADOR_VERSION=${{ inputs.limitadorVersion }}
+          make bundle \
+            REGISTRY=${{ env.IMG_REGISTRY_HOST }} \
+            ORG=${{ env.IMG_REGISTRY_ORG }} \
+            VERSION=${{ env.VERSION }} \
+            IMAGE_TAG=${{ inputs.operatorTag }} \
+            LIMITADOR_VERSION=${{ inputs.limitadorVersion }} \
+            CHANNELS=${{ inputs.channels }}
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2

--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -141,8 +141,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Generate Catalog Content
         run: |
-          make catalog REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} \
-            VERSION=${{ env.VERSION }} IMAGE_TAG=${{ inputs.operatorTag }} LIMITADOR_VERSION=${{ inputs.limitadorVersion }}
+          make catalog \
+            REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} \
+            VERSION=${{ env.VERSION }} IMAGE_TAG=${{ inputs.operatorTag }} \
+            LIMITADOR_VERSION=${{ inputs.limitadorVersion }} \
+            CHANNELS=${{ inputs.channels }}
       - name: Install qemu dependency
         run: |
           sudo apt-get update

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -16,11 +16,12 @@ $(CATALOG_FILE): $(OPM) $(YQ)
 	@echo Build limitador operator catalog
 	@echo
 	@echo BUNDLE_IMG                     = $(BUNDLE_IMG)
+	@echo CHANNELS  					 = $(CHANNELS)
 	@echo "************************************************************"
 	@echo
 	@echo Please check this matches your expectations and override variables if needed.
 	@echo
-	$(PROJECT_PATH)/utils/generate-catalog.sh $(OPM) $(YQ) $(BUNDLE_IMG) $@
+	$(PROJECT_PATH)/utils/generate-catalog.sh $(OPM) $(YQ) $(BUNDLE_IMG) $(CHANNELS) $@
 
 .PHONY: catalog
 catalog: $(OPM) ## Generate catalog content and validate.

--- a/utils/generate-catalog.sh
+++ b/utils/generate-catalog.sh
@@ -6,13 +6,14 @@ set -euo pipefail
 
 ### CONSTANTS
 # Used as well in the subscription object
-CHANNEL_NAME=preview
+DEFAULT_CHANNEL=preview
 ###
 
 OPM="${1?:Error \$OPM not set. Bye}"
 YQ="${2?:Error \$YQ not set. Bye}"
 BUNDLE_IMG="${3?:Error \$BUNDLE_IMG not set. Bye}"
-CATALOG_FILE="${4?:Error \$CATALOG_FILE not set. Bye}"
+CHANNELS="${4:-$DEFAULT_CHANNEL}"
+CATALOG_FILE="${5?:Error \$CATALOG_FILE not set. Bye}"
 
 CATALOG_FILE_BASEDIR="$( cd "$( dirname "$(realpath ${CATALOG_FILE})" )" && pwd )"
 CATALOG_BASEDIR="$( cd "$( dirname "$(realpath ${CATALOG_FILE_BASEDIR})" )" && pwd )"
@@ -28,11 +29,12 @@ touch ${CATALOG_FILE}
 # Limitador Operator
 ###
 # Add the package
-${OPM} init limitador-operator --default-channel=${CHANNEL_NAME} --output yaml >> ${CATALOG_FILE}
+${OPM} init limitador-operator --default-channel=${CHANNELS} --output yaml >> ${CATALOG_FILE}
 # Add a bundles to the Catalog
 cat ${TMP_DIR}/limitador-operator-bundle.yaml >> ${CATALOG_FILE}
 # Add a channel entry for the bundle
 V=`${YQ} eval '.name' ${TMP_DIR}/limitador-operator-bundle.yaml` \
-    ${YQ} eval '(.entries[0].name = strenv(V))' ${CATALOG_BASEDIR}/limitador-operator-channel-entry.yaml >> ${CATALOG_FILE}
+CHANNELS=${CHANNELS} \
+    ${YQ} eval '(.entries[0].name = strenv(V)) | (.name = strenv(CHANNELS))' ${CATALOG_BASEDIR}/limitador-operator-channel-entry.yaml >> ${CATALOG_FILE}
 
 rm -rf $TMP_DIR


### PR DESCRIPTION
This PR is part of Kuadrant Operator issue https://github.com/Kuadrant/kuadrant-operator/issues/244

The workflow dispatch input channels accepts comma separated values, i.e.: "stable,release". The Makefile target could be executed as:

```sh
make bundle \
    REGISTRY=quay.io \
    ORG=kuadrant \
    VERSION=0.5.0 \
    IMAGE_TAG=v0.5.0 \
    LIMITADOR_VERSION=1.2.0 \
    CHANNELS=stable,release
```

And it will generate, among other changes, the following:

```sh
diff --git a/bundle.Dockerfile b/bundle.Dockerfile
index f229f85..bff38ce 100644
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -5,8 +5,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
-LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channels.v1=stable,release

index 02b82cc..20821d7 100644
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -4,8 +4,8 @@ annotations:
-  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channels.v1: stable,release

```

NOTES:
- For catalog generation, it only supports one channel at the moment.