### PR TITLE
Build images with replaces operator image

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -15,6 +15,10 @@ on:
         description: Limitador version
         default: latest
         type: string
+      replacesVersion:
+        description: Limitador Operator replaced version
+        default: 0.0.0-alpha
+        type: string
       channels:
         description: Bundle and catalog channels, comma separated
         default: preview
@@ -32,6 +36,10 @@ on:
       limitadorVersion:
         description: Limitador version
         default: latest
+        type: string
+      replacesVersion:
+        description: Limitador Operator replaced version
+        default: 0.0.0-alpha
         type: string
       channels:
         description: Bundle and catalog channels, comma separated
@@ -104,6 +112,7 @@ jobs:
             VERSION=${{ env.VERSION }} \
             IMAGE_TAG=${{ inputs.operatorTag }} \
             LIMITADOR_VERSION=${{ inputs.limitadorVersion }} \
+            REPLACES_VERSION=${{ inputs.replacesVersion }} \
             CHANNELS=${{ inputs.channels }}
       - name: Build Image
         id: build-image
@@ -145,6 +154,7 @@ jobs:
             REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} \
             VERSION=${{ env.VERSION }} IMAGE_TAG=${{ inputs.operatorTag }} \
             LIMITADOR_VERSION=${{ inputs.limitadorVersion }} \
+            REPLACES_VERSION=${{ inputs.replacesVersion }} \
             CHANNELS=${{ inputs.channels }}
       - name: Install qemu dependency
         run: |

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,11 @@ BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:$(IMAGE_TAG)
 # Image URL to use all building/pushing image targets
 DEFAULT_IMG ?= $(IMAGE_TAG_BASE):$(IMAGE_TAG)
 IMG ?= $(DEFAULT_IMG)
+
+# Limitador Operator replaced version
+DEFAULT_REPLACES_VERSION = 0.0.0-alpha
+REPLACES_VERSION ?= $(DEFAULT_REPLACES_VERSION)
+
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.22
 
@@ -289,6 +294,7 @@ bundle: $(OPM) $(YQ) manifests kustomize operator-sdk ## Generate bundle manifes
 	V="limitador-operator.v$(BUNDLE_VERSION)" $(YQ) eval '.metadata.name = strenv(V)' -i config/manifests/bases/limitador-operator.clusterserviceversion.yaml
 	V="$(BUNDLE_VERSION)" $(YQ) eval '.spec.version = strenv(V)' -i config/manifests/bases/limitador-operator.clusterserviceversion.yaml
 	V="$(IMG)" $(YQ) eval '.metadata.annotations.containerImage = strenv(V)' -i config/manifests/bases/limitador-operator.clusterserviceversion.yaml
+	V="limitador-operator.v$(REPLACES_VERSION)" $(YQ) eval '.spec.replaces = strenv(V)' -i config/manifests/bases/limitador-operator.clusterserviceversion.yaml
 	# Generate bundle
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(BUNDLE_VERSION) $(BUNDLE_METADATA_OPTS)
 	# Validate bundle manifests

--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/limitador-operator:latest
-    createdAt: "2023-09-01T15:47:50Z"
+    createdAt: "2023-09-27T14:09:01Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/limitador-operator
@@ -241,4 +241,5 @@ spec:
   relatedImages:
   - image: quay.io/kuadrant/limitador:latest
     name: limitador
+  replaces: limitador-operator.v0.0.0-alpha
   version: 0.0.0

--- a/config/manifests/bases/limitador-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/limitador-operator.clusterserviceversion.yaml
@@ -53,4 +53,5 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/limitador-operator
+  replaces: limitador-operator.v0.0.0-alpha
   version: 0.0.0

--- a/doc/development.md
+++ b/doc/development.md
@@ -137,9 +137,13 @@ The `make catalog` target accepts the following variables:
 | **Makefile Variable** | **Description**           | **Default value**                                   |
 |-----------------------|---------------------------|-----------------------------------------------------|
 | `BUNDLE_IMG`          | Operator bundle image URL | `quay.io/kuadrant/limitador-operator-bundle:latest` |
+| `REPLACES_VERSION`    | Previous operator version | `0.0.0-alpha`                                       |
+| `CHANNELS`            | Catalog channels          | `preview`                                           |
 
 ```sh
-make catalog [BUNDLE_IMG=quay.io/kuadrant/limitador-operator-bundle:latest]
+make catalog [BUNDLE_IMG=quay.io/kuadrant/limitador-operator-bundle:latest] \
+             [REPLACES_VERSION=0.0.0-alpha] \
+             [CHANNELS=preview]
 ```
 
 * Build the catalog image from the manifests

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -15,13 +15,14 @@ $(CATALOG_FILE): $(OPM) $(YQ)
 	@echo "************************************************************"
 	@echo Build limitador operator catalog
 	@echo
-	@echo BUNDLE_IMG                     = $(BUNDLE_IMG)
-	@echo CHANNELS  					 = $(CHANNELS)
+	@echo BUNDLE_IMG					= $(BUNDLE_IMG)
+	@echo REPLACES						= $(REPLACES)
+	@echo CHANNELS						= $(CHANNELS)
 	@echo "************************************************************"
 	@echo
 	@echo Please check this matches your expectations and override variables if needed.
 	@echo
-	$(PROJECT_PATH)/utils/generate-catalog.sh $(OPM) $(YQ) $(BUNDLE_IMG) $(CHANNELS) $@
+	$(PROJECT_PATH)/utils/generate-catalog.sh $(OPM) $(YQ) $(BUNDLE_IMG) $(REPLACES) $(CHANNELS) $@
 
 .PHONY: catalog
 catalog: $(OPM) ## Generate catalog content and validate.

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -16,13 +16,13 @@ $(CATALOG_FILE): $(OPM) $(YQ)
 	@echo Build limitador operator catalog
 	@echo
 	@echo BUNDLE_IMG					= $(BUNDLE_IMG)
-	@echo REPLACES						= $(REPLACES)
+	@echo REPLACES_VERSION				= $(REPLACES_VERSION)
 	@echo CHANNELS						= $(CHANNELS)
 	@echo "************************************************************"
 	@echo
 	@echo Please check this matches your expectations and override variables if needed.
 	@echo
-	$(PROJECT_PATH)/utils/generate-catalog.sh $(OPM) $(YQ) $(BUNDLE_IMG) $(REPLACES) $(CHANNELS) $@
+	$(PROJECT_PATH)/utils/generate-catalog.sh $(OPM) $(YQ) $(BUNDLE_IMG) $@ $(REPLACES_VERSION) $(CHANNELS)
 
 .PHONY: catalog
 catalog: $(OPM) ## Generate catalog content and validate.

--- a/utils/generate-catalog.sh
+++ b/utils/generate-catalog.sh
@@ -12,6 +12,7 @@ DEFAULT_CHANNEL=preview
 OPM="${1?:Error \$OPM not set. Bye}"
 YQ="${2?:Error \$YQ not set. Bye}"
 BUNDLE_IMG="${3?:Error \$BUNDLE_IMG not set. Bye}"
+REPLACES="${3?:Error \$REPLACES not set. Bye}"
 CHANNELS="${4:-$DEFAULT_CHANNEL}"
 CATALOG_FILE="${5?:Error \$CATALOG_FILE not set. Bye}"
 
@@ -34,7 +35,8 @@ ${OPM} init limitador-operator --default-channel=${CHANNELS} --output yaml >> ${
 cat ${TMP_DIR}/limitador-operator-bundle.yaml >> ${CATALOG_FILE}
 # Add a channel entry for the bundle
 V=`${YQ} eval '.name' ${TMP_DIR}/limitador-operator-bundle.yaml` \
+REPLACES=limitador-operator.v${REPLACES_VERSION} \
 CHANNELS=${CHANNELS} \
-    ${YQ} eval '(.entries[0].name = strenv(V)) | (.name = strenv(CHANNELS))' ${CATALOG_BASEDIR}/limitador-operator-channel-entry.yaml >> ${CATALOG_FILE}
+    ${YQ} eval '(.entries[0].name = strenv(V)) | (.entries[0].replaces = strenv(REPLACES)) | (.name = strenv(CHANNELS))' ${CATALOG_BASEDIR}/limitador-operator-channel-entry.yaml >> ${CATALOG_FILE}
 
 rm -rf $TMP_DIR

--- a/utils/generate-catalog.sh
+++ b/utils/generate-catalog.sh
@@ -7,14 +7,15 @@ set -euo pipefail
 ### CONSTANTS
 # Used as well in the subscription object
 DEFAULT_CHANNEL=preview
+DEFAULT_REPLACES_VERSION=0.0.0-alpha
 ###
 
 OPM="${1?:Error \$OPM not set. Bye}"
 YQ="${2?:Error \$YQ not set. Bye}"
 BUNDLE_IMG="${3?:Error \$BUNDLE_IMG not set. Bye}"
-REPLACES="${3?:Error \$REPLACES not set. Bye}"
-CHANNELS="${4:-$DEFAULT_CHANNEL}"
-CATALOG_FILE="${5?:Error \$CATALOG_FILE not set. Bye}"
+CATALOG_FILE="${4?:Error \$CATALOG_FILE not set. Bye}"
+REPLACES_VERSION="${5:-$DEFAULT_REPLACES_VERSION}"
+CHANNELS="${6:-$DEFAULT_CHANNEL}"
 
 CATALOG_FILE_BASEDIR="$( cd "$( dirname "$(realpath ${CATALOG_FILE})" )" && pwd )"
 CATALOG_BASEDIR="$( cd "$( dirname "$(realpath ${CATALOG_FILE_BASEDIR})" )" && pwd )"


### PR DESCRIPTION
This PR fixes the discrepancy between the bundle replaces value  provided to OperatorHub (by hand) and our bundle and catalog images (missing until now). It aims to fix the failing tests in  both https://github.com/k8s-operatorhub/community-operators/actions/runs/6323398403/job/17171016267?pr=3298 and https://github.com/redhat-openshift-ecosystem/community-operators-prod/actions/runs/6323474102/job/17171305652?pr=3350 . 

Notes:

A re-release needs to be done... either using this mod or by hand including the replaces in the catalog and bundle.
