### PR TITLE
codecov: add target and threshold

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -2,10 +2,21 @@
 codecov:
   bot: "Codecov Bot"
   max_report_age: 12
-  require_ci_to_pass: yes
+  require_ci_to_pass: true
   notify:
     after_n_builds: 1
-    wait_for_ci: yes
+    wait_for_ci: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
 
 # Layout of the PR comment produced by Codecov bot
 comment:
@@ -13,7 +24,7 @@ comment:
 
 # Find more at https://docs.codecov.com/docs/ignoring-paths
 ignore:
-  - "**/*.deepcopy.go" # ignore controller-gen generated code
+  - "**/*.deepcopy.go"  # ignore controller-gen generated code
 
 flag_management:
   individual_flags:


### PR DESCRIPTION
### What

Added [Codecov Status Check](https://docs.codecov.com/docs/commit-status) target and threshold

`target` is the minimum coverage ratio that the commit must meet to be considered a success.

`threshold` allows the coverage to drop by X%, and posting a success status.

```
❯ cat .github/codecov.yaml | curl --data-binary @- https://codecov.io/validate
Valid!
```
