### PR TITLE
Pass Redis URL as Env Var to Limitador deployment.

### DIFF
--- a/api/v1alpha1/limitador_types.go
+++ b/api/v1alpha1/limitador_types.go
@@ -171,7 +171,7 @@ type Storage struct {
 type Redis struct {
 	// +ConfigSecretRef refers to the secret holding the URL for Redis.
 	// +optional
-	ConfigSecretRef *corev1.ObjectReference `json:"configSecretRef,omitempty"`
+	ConfigSecretRef *corev1.LocalObjectReference `json:"configSecretRef,omitempty"`
 }
 
 type RedisCachedOptions struct {
@@ -195,7 +195,7 @@ type RedisCachedOptions struct {
 type RedisCached struct {
 	// +ConfigSecretRef refers to the secret holding the URL for Redis.
 	// +optional
-	ConfigSecretRef *corev1.ObjectReference `json:"configSecretRef,omitempty"`
+	ConfigSecretRef *corev1.LocalObjectReference `json:"configSecretRef,omitempty"`
 
 	// +optional
 	Options *RedisCachedOptions `json:"options,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -161,6 +161,11 @@ func (in *LimitadorSpec) DeepCopyInto(out *LimitadorSpec) {
 		*out = new(RateLimitHeadersType)
 		**out = **in
 	}
+	if in.Telemetry != nil {
+		in, out := &in.Telemetry, &out.Telemetry
+		*out = new(Telemetry)
+		**out = **in
+	}
 	if in.Limits != nil {
 		in, out := &in.Limits, &out.Limits
 		*out = make([]RateLimit, len(*in))

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -358,7 +358,7 @@ func (in *Redis) DeepCopyInto(out *Redis) {
 	*out = *in
 	if in.ConfigSecretRef != nil {
 		in, out := &in.ConfigSecretRef, &out.ConfigSecretRef
-		*out = new(v1.ObjectReference)
+		*out = new(v1.LocalObjectReference)
 		**out = **in
 	}
 }
@@ -378,7 +378,7 @@ func (in *RedisCached) DeepCopyInto(out *RedisCached) {
 	*out = *in
 	if in.ConfigSecretRef != nil {
 		in, out := &in.ConfigSecretRef, &out.ConfigSecretRef
-		*out = new(v1.ObjectReference)
+		*out = new(v1.LocalObjectReference)
 		**out = **in
 	}
 	if in.Options != nil {

--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/limitador-operator:latest
-    createdAt: "2023-11-08T14:12:13Z"
+    createdAt: "2023-11-15T10:55:48Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/limitador-operator

--- a/bundle/manifests/limitador.kuadrant.io_limitadors.yaml
+++ b/bundle/manifests/limitador.kuadrant.io_limitadors.yaml
@@ -1027,66 +1027,13 @@ spec:
                   redis:
                     properties:
                       configSecretRef:
-                        description: "ObjectReference contains enough information
-                          to let you inspect or modify the referred object. --- New
-                          uses of this type are discouraged because of difficulty
-                          describing its usage when embedded in APIs. 1. Ignored fields.
-                          \ It includes many fields which are not generally honored.
-                          \ For instance, ResourceVersion and FieldPath are both very
-                          rarely valid in actual usage. 2. Invalid usage help.  It
-                          is impossible to add specific help for individual usage.
-                          \ In most embedded usages, there are particular restrictions
-                          like, \"must refer only to types A and B\" or \"UID not
-                          honored\" or \"name must be restricted\". Those cannot be
-                          well described when embedded. 3. Inconsistent validation.
-                          \ Because the usages are different, the validation rules
-                          are different by usage, which makes it hard for users to
-                          predict what will happen. 4. The fields are both imprecise
-                          and overly precise.  Kind is not a precise mapping to a
-                          URL. This can produce ambiguity during interpretation and
-                          require a REST mapping.  In most cases, the dependency is
-                          on the group,resource tuple and the version of the actual
-                          struct is irrelevant. 5. We cannot easily change it.  Because
-                          this type is embedded in many locations, updates to this
-                          type will affect numerous schemas.  Don't make new APIs
-                          embed an underspecified API type they do not control. \n
-                          Instead of using this type, create a locally provided and
-                          used type that is well-focused on your reference. For example,
-                          ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                          ."
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
                         properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -1094,66 +1041,13 @@ spec:
                   redis-cached:
                     properties:
                       configSecretRef:
-                        description: "ObjectReference contains enough information
-                          to let you inspect or modify the referred object. --- New
-                          uses of this type are discouraged because of difficulty
-                          describing its usage when embedded in APIs. 1. Ignored fields.
-                          \ It includes many fields which are not generally honored.
-                          \ For instance, ResourceVersion and FieldPath are both very
-                          rarely valid in actual usage. 2. Invalid usage help.  It
-                          is impossible to add specific help for individual usage.
-                          \ In most embedded usages, there are particular restrictions
-                          like, \"must refer only to types A and B\" or \"UID not
-                          honored\" or \"name must be restricted\". Those cannot be
-                          well described when embedded. 3. Inconsistent validation.
-                          \ Because the usages are different, the validation rules
-                          are different by usage, which makes it hard for users to
-                          predict what will happen. 4. The fields are both imprecise
-                          and overly precise.  Kind is not a precise mapping to a
-                          URL. This can produce ambiguity during interpretation and
-                          require a REST mapping.  In most cases, the dependency is
-                          on the group,resource tuple and the version of the actual
-                          struct is irrelevant. 5. We cannot easily change it.  Because
-                          this type is embedded in many locations, updates to this
-                          type will affect numerous schemas.  Don't make new APIs
-                          embed an underspecified API type they do not control. \n
-                          Instead of using this type, create a locally provided and
-                          used type that is well-focused on your reference. For example,
-                          ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                          ."
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
                         properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic

--- a/config/crd/bases/limitador.kuadrant.io_limitadors.yaml
+++ b/config/crd/bases/limitador.kuadrant.io_limitadors.yaml
@@ -1028,66 +1028,13 @@ spec:
                   redis:
                     properties:
                       configSecretRef:
-                        description: "ObjectReference contains enough information
-                          to let you inspect or modify the referred object. --- New
-                          uses of this type are discouraged because of difficulty
-                          describing its usage when embedded in APIs. 1. Ignored fields.
-                          \ It includes many fields which are not generally honored.
-                          \ For instance, ResourceVersion and FieldPath are both very
-                          rarely valid in actual usage. 2. Invalid usage help.  It
-                          is impossible to add specific help for individual usage.
-                          \ In most embedded usages, there are particular restrictions
-                          like, \"must refer only to types A and B\" or \"UID not
-                          honored\" or \"name must be restricted\". Those cannot be
-                          well described when embedded. 3. Inconsistent validation.
-                          \ Because the usages are different, the validation rules
-                          are different by usage, which makes it hard for users to
-                          predict what will happen. 4. The fields are both imprecise
-                          and overly precise.  Kind is not a precise mapping to a
-                          URL. This can produce ambiguity during interpretation and
-                          require a REST mapping.  In most cases, the dependency is
-                          on the group,resource tuple and the version of the actual
-                          struct is irrelevant. 5. We cannot easily change it.  Because
-                          this type is embedded in many locations, updates to this
-                          type will affect numerous schemas.  Don't make new APIs
-                          embed an underspecified API type they do not control. \n
-                          Instead of using this type, create a locally provided and
-                          used type that is well-focused on your reference. For example,
-                          ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                          ."
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
                         properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -1095,66 +1042,13 @@ spec:
                   redis-cached:
                     properties:
                       configSecretRef:
-                        description: "ObjectReference contains enough information
-                          to let you inspect or modify the referred object. --- New
-                          uses of this type are discouraged because of difficulty
-                          describing its usage when embedded in APIs. 1. Ignored fields.
-                          \ It includes many fields which are not generally honored.
-                          \ For instance, ResourceVersion and FieldPath are both very
-                          rarely valid in actual usage. 2. Invalid usage help.  It
-                          is impossible to add specific help for individual usage.
-                          \ In most embedded usages, there are particular restrictions
-                          like, \"must refer only to types A and B\" or \"UID not
-                          honored\" or \"name must be restricted\". Those cannot be
-                          well described when embedded. 3. Inconsistent validation.
-                          \ Because the usages are different, the validation rules
-                          are different by usage, which makes it hard for users to
-                          predict what will happen. 4. The fields are both imprecise
-                          and overly precise.  Kind is not a precise mapping to a
-                          URL. This can produce ambiguity during interpretation and
-                          require a REST mapping.  In most cases, the dependency is
-                          on the group,resource tuple and the version of the actual
-                          struct is irrelevant. 5. We cannot easily change it.  Because
-                          this type is embedded in many locations, updates to this
-                          type will affect numerous schemas.  Don't make new APIs
-                          embed an underspecified API type they do not control. \n
-                          Instead of using this type, create a locally provided and
-                          used type that is well-focused on your reference. For example,
-                          ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                          ."
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
                         properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic

--- a/controllers/limitador_controller.go
+++ b/controllers/limitador_controller.go
@@ -318,7 +318,7 @@ func (r *LimitadorReconciler) getDeploymentOptions(ctx context.Context, limObj *
 	deploymentOptions.VolumeMounts = limitador.DeploymentVolumeMounts(deploymentStorageOptions)
 	deploymentOptions.Volumes = limitador.DeploymentVolumes(limObj, deploymentStorageOptions)
 	deploymentOptions.DeploymentStrategy = deploymentStorageOptions.DeploymentStrategy
-	deploymentOptions.EnvVar, err = r.getDeploymentEnvVar(ctx, limObj)
+	deploymentOptions.EnvVar, err = r.getDeploymentEnvVar(limObj)
 	if err != nil {
 		return deploymentOptions, err
 	}
@@ -346,14 +346,14 @@ func (r *LimitadorReconciler) getDeploymentStorageOptions(ctx context.Context, l
 	return limitador.InMemoryDeploymentOptions()
 }
 
-func (r *LimitadorReconciler) getDeploymentEnvVar(ctx context.Context, limObj *limitadorv1alpha1.Limitador) ([]v1.EnvVar, error) {
+func (r *LimitadorReconciler) getDeploymentEnvVar(limObj *limitadorv1alpha1.Limitador) ([]v1.EnvVar, error) {
 	if limObj.Spec.Storage != nil {
 		if limObj.Spec.Storage.Redis != nil {
-			return limitador.DeploymentEnvVar(ctx, r.Client(), limObj.Namespace, limObj.Spec.Storage.Redis.ConfigSecretRef)
+			return limitador.DeploymentEnvVar(limObj.Spec.Storage.Redis.ConfigSecretRef)
 		}
 
 		if limObj.Spec.Storage.RedisCached != nil {
-			return limitador.DeploymentEnvVar(ctx, r.Client(), limObj.Namespace, limObj.Spec.Storage.RedisCached.ConfigSecretRef)
+			return limitador.DeploymentEnvVar(limObj.Spec.Storage.RedisCached.ConfigSecretRef)
 		}
 	}
 

--- a/controllers/limitador_controller_test.go
+++ b/controllers/limitador_controller_test.go
@@ -839,7 +839,7 @@ var _ = Describe("Limitador controller", func() {
 						"limitador-server",
 						"/home/limitador/etc/limitador-config.yaml",
 						"redis",
-						"redis://example.com:6379",
+						"$(URL)",
 					},
 				),
 			)
@@ -922,7 +922,7 @@ var _ = Describe("Limitador controller", func() {
 						"limitador-server",
 						"/home/limitador/etc/limitador-config.yaml",
 						"redis_cached",
-						"redis://example.com:6379",
+						"$(URL)",
 						"--ttl", "1",
 						"--ratio", "2",
 						"--flush-period", "3",

--- a/controllers/limitador_controller_test.go
+++ b/controllers/limitador_controller_test.go
@@ -839,7 +839,7 @@ var _ = Describe("Limitador controller", func() {
 						"limitador-server",
 						"/home/limitador/etc/limitador-config.yaml",
 						"redis",
-						"$(URL)",
+						"$(LIMITADOR_OPERATOR_REDIS_URL)",
 					},
 				),
 			)
@@ -922,7 +922,7 @@ var _ = Describe("Limitador controller", func() {
 						"limitador-server",
 						"/home/limitador/etc/limitador-config.yaml",
 						"redis_cached",
-						"$(URL)",
+						"$(LIMITADOR_OPERATOR_REDIS_URL)",
 						"--ttl", "1",
 						"--ratio", "2",
 						"--flush-period", "3",

--- a/controllers/limitador_controller_test.go
+++ b/controllers/limitador_controller_test.go
@@ -1028,9 +1028,8 @@ func limitadorWithRedisStorage(redisKey client.ObjectKey) *limitadorv1alpha1.Lim
 		Spec: limitadorv1alpha1.LimitadorSpec{
 			Storage: &limitadorv1alpha1.Storage{
 				Redis: &limitadorv1alpha1.Redis{
-					ConfigSecretRef: &v1.ObjectReference{
-						Name:      redisKey.Name,
-						Namespace: redisKey.Namespace,
+					ConfigSecretRef: &v1.LocalObjectReference{
+						Name: redisKey.Name,
 					},
 				},
 			},
@@ -1045,9 +1044,8 @@ func limitadorWithRedisCachedStorage(key client.ObjectKey) *limitadorv1alpha1.Li
 		Spec: limitadorv1alpha1.LimitadorSpec{
 			Storage: &limitadorv1alpha1.Storage{
 				RedisCached: &limitadorv1alpha1.RedisCached{
-					ConfigSecretRef: &v1.ObjectReference{
-						Name:      key.Name,
-						Namespace: key.Namespace,
+					ConfigSecretRef: &v1.LocalObjectReference{
+						Name: key.Name,
 					},
 					Options: &limitadorv1alpha1.RedisCachedOptions{
 						TTL:         &[]int{1}[0],

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -53,11 +53,11 @@ spec:
     redis:
       configSecretRef: # The secret reference storing the URL for Redis
         name: redisconfig
-        namespace: default # optional
 ```
 
 The URL of the Redis service is provided inside a K8s opaque
 [Secret](https://kubernetes.io/docs/concepts/configuration/secret/).
+The secret is required to be in the same namespace as the `Limitador` CR.
 
 ```yaml
 apiVersion: v1
@@ -87,12 +87,11 @@ spec:
     redis-cached:
       configSecretRef: # The secret reference storing the URL for Redis
         name: redisconfig
-        namespace: default # optional
 ```
 
 The URL of the Redis service is provided inside a K8s opaque
 [Secret](https://kubernetes.io/docs/concepts/configuration/secret/).
-
+The secret is required to be in the same namespace as the `Limitador` CR.
 ```yaml
 apiVersion: v1
 kind: Secret

--- a/pkg/limitador/deployment_options.go
+++ b/pkg/limitador/deployment_options.go
@@ -14,6 +14,7 @@ type DeploymentOptions struct {
 	VolumeMounts       []v1.VolumeMount
 	Volumes            []v1.Volume
 	DeploymentStrategy appsv1.DeploymentStrategy
+	EnvVar             []v1.EnvVar
 }
 
 type DeploymentStorageOptions struct {

--- a/pkg/limitador/k8s_objects.go
+++ b/pkg/limitador/k8s_objects.go
@@ -92,6 +92,7 @@ func Deployment(limitador *limitadorv1alpha1.Limitador, deploymentOptions Deploy
 							Name:    "limitador",
 							Image:   image,
 							Command: deploymentOptions.Command,
+							Env:     deploymentOptions.EnvVar,
 							Ports: []v1.ContainerPort{
 								{
 									Name:          "http",

--- a/pkg/limitador/redis_cache_storage_options.go
+++ b/pkg/limitador/redis_cache_storage_options.go
@@ -14,12 +14,12 @@ func RedisCachedDeploymentOptions(ctx context.Context, cl client.Client, defSecr
 		return DeploymentStorageOptions{}, errors.New("there's no ConfigSecretRef set")
 	}
 
-	redisURL, err := getURLFromRedisSecret(ctx, cl, defSecretNamespace, *redisCachedObj.ConfigSecretRef)
+	err := validateRedisSecret(ctx, cl, defSecretNamespace, *redisCachedObj.ConfigSecretRef)
 	if err != nil {
 		return DeploymentStorageOptions{}, err
 	}
 
-	command := []string{"redis_cached", redisURL}
+	command := []string{"redis_cached", "$(LIMITADOR_OPERATOR_REDIS_URL)"}
 	if redisCachedObj.Options != nil {
 		if redisCachedObj.Options.TTL != nil {
 			command = append(command, "--ttl", strconv.Itoa(*redisCachedObj.Options.TTL))

--- a/pkg/limitador/redis_cache_storage_options_test.go
+++ b/pkg/limitador/redis_cache_storage_options_test.go
@@ -47,7 +47,7 @@ func TestRedisCachedDeploymentOptions(t *testing.T) {
 	t.Run("redis secret resource missing", func(subT *testing.T) {
 		cl := clientFactory(subT, nil)
 		redisObj := limitadorv1alpha1.RedisCached{
-			ConfigSecretRef: &v1.ObjectReference{Name: "notexisting", Namespace: namespace},
+			ConfigSecretRef: &v1.LocalObjectReference{Name: "notexisting"},
 		}
 		_, err := RedisCachedDeploymentOptions(ctx, cl, namespace, redisObj)
 		assert.Assert(subT, errors.IsNotFound(err))
@@ -63,7 +63,7 @@ func TestRedisCachedDeploymentOptions(t *testing.T) {
 		}
 		cl := clientFactory(subT, []client.Object{emptySecret})
 		redisObj := limitadorv1alpha1.RedisCached{
-			ConfigSecretRef: &v1.ObjectReference{Name: "redisSecret", Namespace: namespace},
+			ConfigSecretRef: &v1.LocalObjectReference{Name: "redisSecret"},
 		}
 		_, err := RedisCachedDeploymentOptions(ctx, cl, namespace, redisObj)
 		assert.Error(subT, err, "the storage config Secret doesn't have the `URL` field")
@@ -80,7 +80,7 @@ func TestRedisCachedDeploymentOptions(t *testing.T) {
 
 		cl := clientFactory(subT, []client.Object{redisSecret})
 		redisObj := limitadorv1alpha1.RedisCached{
-			ConfigSecretRef: &v1.ObjectReference{Name: "redisSecret", Namespace: namespace},
+			ConfigSecretRef: &v1.LocalObjectReference{Name: "redisSecret"},
 		}
 		options, err := RedisCachedDeploymentOptions(ctx, cl, namespace, redisObj)
 		assert.NilError(subT, err)
@@ -102,7 +102,7 @@ func TestRedisCachedDeploymentOptions(t *testing.T) {
 
 		cl := clientFactory(subT, []client.Object{redisSecret})
 		redisObj := limitadorv1alpha1.RedisCached{
-			ConfigSecretRef: &v1.ObjectReference{Name: "redisSecret", Namespace: namespace},
+			ConfigSecretRef: &v1.LocalObjectReference{Name: "redisSecret"},
 			Options: &limitadorv1alpha1.RedisCachedOptions{
 				TTL:         &[]int{1}[0],
 				Ratio:       &[]int{2}[0],

--- a/pkg/limitador/redis_cache_storage_options_test.go
+++ b/pkg/limitador/redis_cache_storage_options_test.go
@@ -86,7 +86,7 @@ func TestRedisCachedDeploymentOptions(t *testing.T) {
 		assert.NilError(subT, err)
 		assert.DeepEqual(subT, options,
 			DeploymentStorageOptions{
-				Command: []string{"redis_cached", "redis://example.com:6379"},
+				Command: []string{"redis_cached", "$(URL)"},
 			},
 		)
 	})
@@ -116,7 +116,7 @@ func TestRedisCachedDeploymentOptions(t *testing.T) {
 			DeploymentStorageOptions{
 				Command: []string{
 					"redis_cached",
-					"redis://example.com:6379",
+					"$(URL)",
 					"--ttl", "1",
 					"--ratio", "2",
 					"--flush-period", "3",

--- a/pkg/limitador/redis_cache_storage_options_test.go
+++ b/pkg/limitador/redis_cache_storage_options_test.go
@@ -86,7 +86,7 @@ func TestRedisCachedDeploymentOptions(t *testing.T) {
 		assert.NilError(subT, err)
 		assert.DeepEqual(subT, options,
 			DeploymentStorageOptions{
-				Command: []string{"redis_cached", "$(URL)"},
+				Command: []string{"redis_cached", "$(LIMITADOR_OPERATOR_REDIS_URL)"},
 			},
 		)
 	})
@@ -116,7 +116,7 @@ func TestRedisCachedDeploymentOptions(t *testing.T) {
 			DeploymentStorageOptions{
 				Command: []string{
 					"redis_cached",
-					"$(URL)",
+					"$(LIMITADOR_OPERATOR_REDIS_URL)",
 					"--ttl", "1",
 					"--ratio", "2",
 					"--flush-period", "3",

--- a/pkg/limitador/redis_storage_options.go
+++ b/pkg/limitador/redis_storage_options.go
@@ -26,19 +26,14 @@ func RedisDeploymentOptions(ctx context.Context, cl client.Client, defSecretName
 	}, nil
 }
 
-func DeploymentEnvVar(ctx context.Context, cl client.Client, defSecretNamespace string, configSecretRef *v1.ObjectReference) ([]v1.EnvVar, error) {
+func DeploymentEnvVar(configSecretRef *v1.ObjectReference) ([]v1.EnvVar, error) {
 	if configSecretRef == nil {
 		return nil, errors.New("there's no ConfigSecretRef set")
 	}
 
-	_, err := getURLFromRedisSecret(ctx, cl, defSecretNamespace, *configSecretRef)
-	if err != nil {
-		return nil, err
-	}
-
 	env := []v1.EnvVar{
 		{
-			Name: "URL",
+			Name: "LIMITADOR_OPERATOR_REDIS_URL",
 			ValueFrom: &v1.EnvVarSource{
 				SecretKeyRef: &v1.SecretKeySelector{
 					Key: "URL",
@@ -73,7 +68,7 @@ func getURLFromRedisSecret(ctx context.Context, cl client.Client, defSecretNames
 
 	// nil map behaves as empty map when reading
 	if _, ok := secret.Data["URL"]; ok {
-		return "$(URL)", nil
+		return "$(LIMITADOR_OPERATOR_REDIS_URL)", nil
 	}
 
 	return "", errors.New("the storage config Secret doesn't have the `URL` field")

--- a/pkg/limitador/redis_storage_options.go
+++ b/pkg/limitador/redis_storage_options.go
@@ -26,7 +26,7 @@ func RedisDeploymentOptions(ctx context.Context, cl client.Client, defSecretName
 	}, nil
 }
 
-func DeploymentEnvVar(configSecretRef *v1.ObjectReference) ([]v1.EnvVar, error) {
+func DeploymentEnvVar(configSecretRef *v1.LocalObjectReference) ([]v1.EnvVar, error) {
 	if configSecretRef == nil {
 		return nil, errors.New("there's no ConfigSecretRef set")
 	}
@@ -47,18 +47,13 @@ func DeploymentEnvVar(configSecretRef *v1.ObjectReference) ([]v1.EnvVar, error) 
 	return env, nil
 }
 
-func validateRedisSecret(ctx context.Context, cl client.Client, defSecretNamespace string, secretRef v1.ObjectReference) error {
+func validateRedisSecret(ctx context.Context, cl client.Client, defSecretNamespace string, secretRef v1.LocalObjectReference) error {
 	secret := &v1.Secret{}
 	if err := cl.Get(
 		ctx,
 		types.NamespacedName{
-			Name: secretRef.Name,
-			Namespace: func() string {
-				if secretRef.Namespace != "" {
-					return secretRef.Namespace
-				}
-				return defSecretNamespace
-			}(),
+			Name:      secretRef.Name,
+			Namespace: defSecretNamespace,
 		},
 		secret,
 	); err != nil {

--- a/pkg/limitador/redis_storage_options_test.go
+++ b/pkg/limitador/redis_storage_options_test.go
@@ -104,7 +104,7 @@ func TestRedisDeploymentOptions(t *testing.T) {
 
 func TestDeploymentEnvVar(t *testing.T) {
 	type args struct {
-		configSecretRef    *v1.ObjectReference
+		configSecretRef *v1.ObjectReference
 	}
 	tests := []struct {
 		name    string

--- a/pkg/limitador/redis_storage_options_test.go
+++ b/pkg/limitador/redis_storage_options_test.go
@@ -57,7 +57,7 @@ func TestRedisDeploymentOptions(t *testing.T) {
 	t.Run("redis secret resource missing", func(subT *testing.T) {
 		cl := clientFactory(subT, nil)
 		redisObj := limitadorv1alpha1.Redis{
-			ConfigSecretRef: &v1.ObjectReference{Name: "notexisting", Namespace: namespace},
+			ConfigSecretRef: &v1.LocalObjectReference{Name: "notexisting"},
 		}
 		_, err := RedisDeploymentOptions(ctx, cl, namespace, redisObj)
 		assert.Assert(subT, errors.IsNotFound(err))
@@ -73,7 +73,7 @@ func TestRedisDeploymentOptions(t *testing.T) {
 		}
 		cl := clientFactory(subT, []client.Object{emptySecret})
 		redisObj := limitadorv1alpha1.Redis{
-			ConfigSecretRef: &v1.ObjectReference{Name: "redisSecret", Namespace: namespace},
+			ConfigSecretRef: &v1.LocalObjectReference{Name: "redisSecret"},
 		}
 		_, err := RedisDeploymentOptions(ctx, cl, namespace, redisObj)
 		assert.Error(subT, err, "the storage config Secret doesn't have the `URL` field")
@@ -90,7 +90,7 @@ func TestRedisDeploymentOptions(t *testing.T) {
 
 		cl := clientFactory(subT, []client.Object{redisSecret})
 		redisObj := limitadorv1alpha1.Redis{
-			ConfigSecretRef: &v1.ObjectReference{Name: "redisSecret", Namespace: namespace},
+			ConfigSecretRef: &v1.LocalObjectReference{Name: "redisSecret"},
 		}
 		options, err := RedisDeploymentOptions(ctx, cl, namespace, redisObj)
 		assert.NilError(subT, err)
@@ -104,7 +104,7 @@ func TestRedisDeploymentOptions(t *testing.T) {
 
 func TestDeploymentEnvVar(t *testing.T) {
 	type args struct {
-		configSecretRef *v1.ObjectReference
+		configSecretRef *v1.LocalObjectReference
 	}
 	tests := []struct {
 		name    string
@@ -136,7 +136,7 @@ func TestDeploymentEnvVar(t *testing.T) {
 			},
 			wantErr: false,
 			args: args{
-				configSecretRef: &v1.ObjectReference{
+				configSecretRef: &v1.LocalObjectReference{
 					Name: "test",
 				},
 			},

--- a/pkg/reconcilers/deployment.go
+++ b/pkg/reconcilers/deployment.go
@@ -97,6 +97,17 @@ func DeploymentCommandMutator(desired, existing *appsv1.Deployment) bool {
 	return update
 }
 
+func DeploymentEnvMutator(desired, existing *appsv1.Deployment) bool {
+	update := false
+
+	if !reflect.DeepEqual(existing.Spec.Template.Spec.Containers[0].Env, desired.Spec.Template.Spec.Containers[0].Env) {
+		existing.Spec.Template.Spec.Containers[0].Env = desired.Spec.Template.Spec.Containers[0].Env
+		update = true
+	}
+
+	return update
+}
+
 func DeploymentResourcesMutator(desired, existing *appsv1.Deployment) bool {
 	update := false
 

--- a/pkg/reconcilers/deployment_test.go
+++ b/pkg/reconcilers/deployment_test.go
@@ -136,6 +136,44 @@ func TestDeploymentResourcesMutator(t *testing.T) {
 	})
 }
 
+func TestDeploymentEnvMutator(t *testing.T) {
+	deploymentFactory := func(env []corev1.EnvVar) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Env: env,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	envFactory := func(name string) []corev1.EnvVar {
+		return []corev1.EnvVar{
+			{
+				Name: name,
+			},
+		}
+	}
+
+	envA := envFactory("envA")
+	envB := envFactory("envB")
+
+	t.Run("test false when desired and existing are the same", func(subT *testing.T) {
+		assert.Equal(subT, reconcilers.DeploymentEnvMutator(deploymentFactory(envA), deploymentFactory(envA)), false)
+	})
+
+	t.Run("test true when desired and existing are different", func(subT *testing.T) {
+		assert.Equal(subT, reconcilers.DeploymentEnvMutator(deploymentFactory(envA), deploymentFactory(envB)), true)
+	})
+}
+
 func TestDeploymentVolumesMutator(t *testing.T) {
 	deploymentFactory := func(volumes []corev1.Volume) *appsv1.Deployment {
 		return &appsv1.Deployment{


### PR DESCRIPTION
Closes: https://github.com/Kuadrant/limitador-operator/issues/106 

This change pass the Redis URL to the limitador-server as a Environment Variable in the deployment config.

# Verification

Verification steps requires  Redis to be configured in the cluster so the running limitador does not have connection error logs.   

Set up the kind cluster with this deployment.
```
make local-setup
```

Create redis deployment, service and secret. The secret will be used in the limitador deployment and should be created in the same namespace. See changes in docs about this.
```sh
echo "
apiVersion: v1
kind: Secret
metadata:
  name: redisconfig
stringData:
  URL: redis://redis.default.svc.cluster.local/0
type: Opaque
---
apiVersion: v1
kind: Service
metadata:
  name: redis
spec:
  ports:
  - port: 6379
    protocol: TCP
    targetPort: 6379
  selector:
    app: redis
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: redis
spec:
  replicas: 1
  selector:
    matchLabels:
      app: redis
  template:
    metadata:
      labels:
        app: redis
    spec:
      containers:
      - image: redis:latest
        name: redis
        ports:
        - containerPort: 6379
  " | kubectl apply -f -
```

## Verify the redis connections work.
Deploy limitador with redis.
```sh
echo "
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador-sample
spec:
  storage:
    redis:
      configSecretRef: 
        name: redisconfig
" | kubectl apply -f -
```
Once deployment is complete:
* check the limitador deployment
```sh
kubectl get deployment limitador-sample -n default -o yaml
```
Expected output to contain
```yaml
spec:
      containers:
      - command:
        - limitador-server
        - /home/limitador/etc/limitador-config.yaml
        - redis
        - $(LIMITIADOR_OPERATOR_REDIS_URL)
        env:
        - name: LIMITIADOR_OPERATOR_REDIS_URL
          valueFrom:
            secretKeyRef:
              key: URL
              name: redisconfig
```
Expect logs not to contain any errors
```sh
kubectl logs deployment/limitador-sample -n default
```

## Verify the rediscache connections work.
Deploy limitador with rediscache.
```sh
echo "
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador-sample
spec:
  storage:
    redis-cached:
      configSecretRef: 
        name: redisconfig
      options:
        ttl: 1000
        max-cached: 5000
" | kubectl apply -f -
```
Once deployment is complete:
* check the limitador deployment
```sh
kubectl get deployment limitador-sample -n default -o yaml
```
Expected output to contain
```yaml
spec:
   containers:
      - command:
        - limitador-server
        - /home/limitador/etc/limitador-config.yaml
        - redis_cached
        - $(LIMITIADOR_OPERATOR_REDIS_URL)
        - --ttl
        - "1000"
        - --max-cached
        - "5000"
        env:
        - name: LIMITIADOR_OPERATOR_REDIS_URL
          valueFrom:
              secretKeyRef:
                 key: URL
                 name: redisconfig
```
Expect logs not to contain any errors
```sh
kubectl logs deployment/limitador-sample -n default
```

## Verify the disk connections work.
This does not use the redis but sets custom command arguments.

Deploy limitador with disk storage.
```sh
echo "
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador-sample
spec:
  storage:
    disk:
       optimize: disk
" | kubectl apply -f -
```
Once deployment is complete:
* check the limitador deployment
```sh
kubectl get deployment limitador-sample -n default -o yaml
```
Expected output to contain
```yaml
 spec:
      containers:
      - command:
        - limitador-server
        - /home/limitador/etc/limitador-config.yaml
        - disk
        - --optimize
        - disk
        - /var/lib/limitador/data
```
Expect logs not to contain any errors
```sh
kubectl logs deployment/limitador-sample -n default
```

## Verify the default / in-memory deployment.
This does not use the redis and does not set custom commands.

Deploy limitador with disk storage.
```sh
echo "
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador-sample
spec:
  storage: null
" | kubectl apply -f -
```
Once deployment is complete:
* check the limitador deployment
```sh
kubectl get deployment limitador-sample -n default -o yaml
```
Expected output to contain
```yaml
    spec:
      containers:
      - command:
        - limitador-server
        - /home/limitador/etc/limitador-config.yaml
        - memory
```
Expect logs not to contain any errors
```sh
kubectl logs deployment/limitador-sample -n default
```

## Error logs in Operator
If redis secret is mising:
```
2023-11-14T15:57:55Z    ERROR    Reconciler error    {"controller": "limitador", "controllerGroup": "limitador.kuadrant.io", "controllerKind": "Limitador", "Limitador": {"name":"limitador-sample","namespace":"default"}, "namespace": "default", "name": "limitador-sample", "reconcileID": "a5fcf752-3209-4665-9b4a-aa5861b8ccdb", "error": "Secret \"redisconfig\" not found"}
```

If URL field is missing from the secret:
```
023-11-14T15:54:05Z    ERROR    Reconciler error    {"controller": "limitador", "controllerGroup": "limitador.kuadrant.io", "controllerKind": "Limitador" , "Limitador": {"name":"limitador-sample","namespace":"default"}, "namespace": "default", "name": "limitador-sample", "reconcileID": "0ec16398-6b0c-4af2-b22a-372c2f9fd300", "error": "the storage config Secret doesn't have the `URL` field"}
```

