### PR TITLE
Enable per limit metrics

### DIFF
--- a/api/v1alpha1/limitador_types.go
+++ b/api/v1alpha1/limitador_types.go
@@ -77,6 +77,9 @@ type LimitadorSpec struct {
 	RateLimitHeaders *RateLimitHeadersType `json:"rateLimitHeaders,omitempty"`
 
 	// +optional
+	Telemetry *Telemetry `json:"telemetry,omitempty"`
+
+	// +optional
 	Limits []RateLimit `json:"limits,omitempty"`
 
 	// +optional
@@ -148,6 +151,10 @@ type LimitadorList struct {
 // RateLimitHeadersType defines the valid options for the --rate-limit-headers arg
 // +kubebuilder:validation:Enum=NONE;DRAFT_VERSION_03
 type RateLimitHeadersType string
+
+// Telemetry defines the level of metrics Limitador will expose to the user
+// +kubebuilder:validation:Enum=basic;exhaustive
+type Telemetry string
 
 // Storage contains the options for Limitador counters database or in-memory data storage
 type Storage struct {

--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/limitador-operator:latest
-    createdAt: "2023-11-08T14:01:55Z"
+    createdAt: "2023-11-08T14:12:13Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/limitador-operator

--- a/bundle/manifests/limitador.kuadrant.io_limitadors.yaml
+++ b/bundle/manifests/limitador.kuadrant.io_limitadors.yaml
@@ -1178,6 +1178,13 @@ spec:
                         type: object
                     type: object
                 type: object
+              telemetry:
+                description: Telemetry defines the level of metrics Limitador will
+                  expose to the user
+                enum:
+                - basic
+                - exhaustive
+                type: string
               version:
                 type: string
             type: object

--- a/config/crd/bases/limitador.kuadrant.io_limitadors.yaml
+++ b/config/crd/bases/limitador.kuadrant.io_limitadors.yaml
@@ -1179,6 +1179,13 @@ spec:
                         type: object
                     type: object
                 type: object
+              telemetry:
+                description: Telemetry defines the level of metrics Limitador will
+                  expose to the user
+                enum:
+                - basic
+                - exhaustive
+                type: string
               version:
                 type: string
             type: object

--- a/pkg/limitador/deployment_options.go
+++ b/pkg/limitador/deployment_options.go
@@ -37,6 +37,10 @@ func DeploymentCommand(limObj *limitadorv1alpha1.Limitador, storageOptions Deplo
 		command = append(command, "--rate-limit-headers", string(*limObj.Spec.RateLimitHeaders))
 	}
 
+	if limObj.Spec.Telemetry != nil && *limObj.Spec.Telemetry == "exhaustive" {
+		command = append(command, "--limit-name-in-labels")
+	}
+
 	command = append(command, filepath.Join(LimitadorCMMountPath, LimitadorConfigFileName))
 	command = append(command, storageOptions.Command...)
 


### PR DESCRIPTION
This builds on the changes in #112 - which lets a `RateLimit` have a name.

Add the `telemetry` field to the `LimitadorSpec`, which currently has two valid options: `basic` (what it's been so far) and `exhaustive`, which will result in starting the Limitador server process with the `--limit-name-in-labels` option, resulting in the two metrics, `limited_calls` & `authorized_calls`, to include the limit's name field as label - providing better metrics about what `Limit` is limiting or allow traffic through.