### PR TITLE
Maintenance/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Operator to manage [Limitador](https://github.com/Kuadrant/limitador) deploy
 
 ### Limitador CRD
 
-[Limitador v1alpha1 API reference](./api/v1alpha1/limitador_types.go)
+[Limitador v1alpha1 API reference](https://github.com/Kuadrant/limitador-operator/tree/main/api/v1alpha1/limitador_types.go)
 
 Example:
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -1,23 +1,5 @@
 # Development Guide
 
-<!--ts-->
-   * [Technology stack required for development](#technology-stack-required-for-development)
-   * [Build](#build)
-   * [Run locally](#run-locally)
-   * [Deploy the operator in a deployment object](#deploy-the-operator-in-a-deployment-object)
-   * [Deploy the operator using OLM](#deploy-the-operator-using-olm)
-   * [Build custom OLM catalog](#build-custom-olm-catalog)
-      * [Build operator bundle image](#build-operator-bundle-image)
-      * [Build custom catalog](#build-custom-catalog)
-   * [Cleaning up](#cleaning-up)
-   * [Run tests](#run-tests)
-      * [Lint tests](#lint-tests)
-   * [(Un)Install Limitador CRD](#uninstall-limitador-crd)
-
-<!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-
-<!--te-->
-
 ## Technology stack required for development
 
 * [operator-sdk] version v1.28.1

--- a/doc/logging.md
+++ b/doc/logging.md
@@ -1,6 +1,7 @@
 # Logging
 
 The limitador operator outputs 3 levels of log messages: (from lowest to highest level)
+
 1. `debug`
 2. `info` (default)
 3. `error`

--- a/doc/rate-limit-headers.md
+++ b/doc/rate-limit-headers.md
@@ -13,8 +13,10 @@ spec:
 ```
 
 Current valid values are:
-* *DRAFT_VERSION_03* (ref: https://datatracker.ietf.org/doc/id/draft-polli-ratelimit-headers-03.html)
-* *NONE*
+
+- *DRAFT_VERSION_03* (ref: 
+[Rate Limit Headers Draft](https://datatracker.ietf.org/doc/id/draft-polli-ratelimit-headers-03.html))
+- *NONE*
 
 By default, when `spec.rateLimitHeaders` is *null*, `--rate-limit-headers` command line arg is not
 included in the limitador's deployment.


### PR DESCRIPTION
- Update docs for better rendering of dos.kaudrant.io
- fix broken links

# Verification 
- Edited markdown pages should render correctly in
  -  Github
  - Docs.kuadrant,io
- All links should work in both locations

To help with rendering these changes on the docs site, https://github.com/Kuadrant/docs.kuadrant.io/pull/41 can be used to run these changes locally