### PR TITLE
Upgrading operator-sdk to v1.32.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ all: build
 ##@ Tools
 
 OPERATOR_SDK = $(PROJECT_PATH)/bin/operator-sdk
-OPERATOR_SDK_VERSION = v1.28.1
+OPERATOR_SDK_VERSION = v1.32.0
 $(OPERATOR_SDK):
 	./utils/install-operator-sdk.sh $(OPERATOR_SDK) $(OPERATOR_SDK_VERSION)
 

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=limitador-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.28.1
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.32.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -37,8 +37,8 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/limitador-operator:latest
-    createdAt: "2023-11-21T22:28:31Z"
-    operators.operatorframework.io/builder: operator-sdk-v1.28.1
+    createdAt: "2024-03-05T09:17:17Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/limitador-operator
     support: kuadrant

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: limitador-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.1
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.32.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 


### PR DESCRIPTION
### What

This PR fixes the https://github.com/operator-framework/operator-sdk/issues/6489 that was fixed in [v1.31.0](https://newreleases.io/project/github/operator-framework/operator-sdk/release/v1.31.0).

## Verification Steps

```sh
rm -rf bin
```

Setup a local cluster with OLM:

```sh
make kind-delete-cluster kind-create-cluster install-olm
```

The command does not return error. Additionally, check OLM is installed

```
k get csv packageserver -n olm 
```
Resulting in 
```
NAME            DISPLAY          VERSION   REPLACES   PHASE
packageserver   Package Server   0.27.0               Succeeded
```
