### PR TITLE
feat: immediate limits sync to pod via annotation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.2.0
         with:
-          version: v0.20.0
+          version: v0.22.0
           config: utils/kind-cluster.yaml
           cluster_name: limitador-local
           wait: 120s

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ opm: $(OPM) ## Download opm locally if necessary.
 
 KIND = $(PROJECT_PATH)/bin/kind
 $(KIND):
-	$(call go-install-tool,$(KIND),sigs.k8s.io/kind@v0.20.0)
+	$(call go-install-tool,$(KIND),sigs.k8s.io/kind@v0.22.0)
 
 .PHONY: kind
 kind: $(KIND) ## Download kind locally if necessary.

--- a/api/v1alpha1/limitador_types.go
+++ b/api/v1alpha1/limitador_types.go
@@ -18,9 +18,11 @@ package v1alpha1
 
 import (
 	"reflect"
+	"strconv"
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
+	"github.com/mitchellh/hashstructure"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +34,9 @@ import (
 const (
 	DefaultServiceHTTPPort int32 = 8080
 	DefaultServiceGRPCPort int32 = 8081
+	DefaultReplicas        int32 = 1
+
+	PodAnnotationLimitsHash string = "limits-hash"
 
 	// Status conditions
 	StatusConditionReady string = "Ready"
@@ -145,6 +150,22 @@ func (l *Limitador) GetResourceRequirements() *corev1.ResourceRequirements {
 	}
 
 	return l.Spec.ResourceRequirements
+}
+
+func (l *Limitador) GetReplicas() int32 {
+	if l.Spec.Replicas == nil {
+		return DefaultReplicas
+	}
+
+	return int32(*l.Spec.Replicas)
+}
+
+func (l *Limitador) LimitsHash() (string, error) {
+	hash, err := hashstructure.Hash(l.Limits(), nil)
+	if err != nil {
+		return "", err
+	}
+	return strconv.FormatUint(hash, 10), nil
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/limitador_types.go
+++ b/api/v1alpha1/limitador_types.go
@@ -18,11 +18,9 @@ package v1alpha1
 
 import (
 	"reflect"
-	"strconv"
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
-	"github.com/mitchellh/hashstructure"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +34,7 @@ const (
 	DefaultServiceGRPCPort int32 = 8081
 	DefaultReplicas        int32 = 1
 
-	PodAnnotationLimitsHash string = "limits-hash"
+	PodAnnotationConfigMapResourceVersion string = "limits-cm-resource-version"
 
 	// Status conditions
 	StatusConditionReady string = "Ready"
@@ -158,14 +156,6 @@ func (l *Limitador) GetReplicas() int32 {
 	}
 
 	return int32(*l.Spec.Replicas)
-}
-
-func (l *Limitador) LimitsHash() (string, error) {
-	hash, err := hashstructure.Hash(l.Limits(), nil)
-	if err != nil {
-		return "", err
-	}
-	return strconv.FormatUint(hash, 10), nil
 }
 
 //+kubebuilder:object:root=true

--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -75,6 +75,14 @@ spec:
           - update
           - watch
         - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - list
+          - update
+          - watch
+        - apiGroups:
           - apps
           resources:
           - deployments

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,6 +20,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - update
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/controllers/limitador_controller_affinity_test.go
+++ b/controllers/limitador_controller_affinity_test.go
@@ -1,8 +1,6 @@
 package controllers
 
 import (
-	"context"
-	"reflect"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -17,14 +15,19 @@ import (
 )
 
 var _ = Describe("Limitador controller manages affinity", func() {
-
+	const (
+		nodeTimeOut = NodeTimeout(time.Second * 30)
+		specTimeOut = SpecTimeout(time.Minute * 2)
+	)
 	var testNamespace string
 
-	BeforeEach(func() {
-		CreateNamespace(&testNamespace)
-	})
+	BeforeEach(func(ctx SpecContext) {
+		CreateNamespaceWithContext(ctx, &testNamespace)
+	}, nodeTimeOut)
 
-	AfterEach(DeleteNamespaceCallback(&testNamespace))
+	AfterEach(func(ctx SpecContext) {
+		DeleteNamespaceWithContext(ctx, &testNamespace)
+	}, nodeTimeOut)
 
 	Context("Creating a new Limitador object with specific affinity", func() {
 		var limitadorObj *limitadorv1alpha1.Limitador
@@ -47,29 +50,27 @@ var _ = Describe("Limitador controller manages affinity", func() {
 			},
 		}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			limitadorObj = basicLimitador(testNamespace)
 			limitadorObj.Spec.Affinity = affinity
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
-		})
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
+		}, nodeTimeOut)
 
-		It("Should create a new deployment with the custom affinity", func() {
+		It("Should create a new deployment with the custom affinity", func(ctx SpecContext) {
 			deployment := appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(
-					context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(
+					ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
 					},
-					&deployment)
-
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+					&deployment)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			Expect(deployment.Spec.Template.Spec.Affinity).To(Equal(affinity))
-		})
+		}, specTimeOut)
 	})
 
 	Context("Updating limitador object with new affinity settings", func() {
@@ -93,54 +94,43 @@ var _ = Describe("Limitador controller manages affinity", func() {
 			},
 		}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			limitadorObj = basicLimitador(testNamespace)
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
-		})
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
+		}, nodeTimeOut)
 
-		It("Should modify the deployment with the affinity custom settings", func() {
+		It("Should modify the deployment with the affinity custom settings", func(ctx SpecContext) {
 			deployment := appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(), types.NamespacedName{
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
 					Namespace: testNamespace,
 					Name:      limitador.DeploymentName(limitadorObj),
-				}, &deployment)
-
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+				}, &deployment)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			Expect(deployment.Spec.Template.Spec.Affinity).To(BeNil())
 
 			updatedLimitador := limitadorv1alpha1.Limitador{}
-			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(), types.NamespacedName{
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
 					Namespace: testNamespace,
 					Name:      limitadorObj.Name,
-				}, &updatedLimitador)
-
-				if err != nil {
-					return false
-				}
+				}, &updatedLimitador)).Should(Succeed())
 
 				updatedLimitador.Spec.Affinity = affinity.DeepCopy()
 
-				return k8sClient.Update(context.TODO(), &updatedLimitador) == nil
-			}, timeout, interval).Should(BeTrue())
+				g.Expect(k8sClient.Update(ctx, &updatedLimitador)).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				newDeployment := appsv1.Deployment{}
-				err := k8sClient.Get(context.TODO(), types.NamespacedName{
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
 					Namespace: testNamespace,
 					Name:      limitador.DeploymentName(limitadorObj),
-				}, &newDeployment)
-
-				if err != nil {
-					return false
-				}
-
-				return reflect.DeepEqual(newDeployment.Spec.Template.Spec.Affinity, affinity)
-			}, timeout, interval).Should(BeTrue())
-		})
+				}, &newDeployment)).To(Succeed())
+				g.Expect(newDeployment.Spec.Template.Spec.Affinity).Should(Equal(affinity))
+			}).WithContext(ctx).Should(Succeed())
+		}, specTimeOut)
 	})
 })

--- a/controllers/limitador_controller_limits_sync_test.go
+++ b/controllers/limitador_controller_limits_sync_test.go
@@ -1,0 +1,228 @@
+package controllers
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/remotecommand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
+	"github.com/kuadrant/limitador-operator/pkg/limitador"
+)
+
+var _ = Describe("Limitador controller syncs limits to pod", func() {
+	const (
+		nodeTimeOut = NodeTimeout(time.Second * 30)
+		specTimeOut = SpecTimeout(time.Minute)
+	)
+
+	var testNamespace string
+
+	BeforeEach(func(ctx SpecContext) {
+		CreateNamespaceWithContext(ctx, &testNamespace)
+	}, nodeTimeOut)
+
+	AfterEach(func(ctx SpecContext) {
+		DeleteNamespaceWithContext(ctx, &testNamespace)
+	}, nodeTimeOut)
+
+	Context("Creating a new Limitador object with default replicas", func() {
+		var limitadorObj *limitadorv1alpha1.Limitador
+
+		limits := []limitadorv1alpha1.RateLimit{
+			{
+				Conditions: []string{"req.method == 'GET'"},
+				MaxValue:   10,
+				Namespace:  "test-namespace",
+				Seconds:    60,
+				Variables:  []string{"user_id"},
+				Name:       "useless",
+			},
+			{
+				Conditions: []string{"req.method == 'POST'"},
+				MaxValue:   5,
+				Namespace:  "test-namespace",
+				Seconds:    60,
+				Variables:  []string{"user_id"},
+			},
+		}
+
+		BeforeEach(func(ctx SpecContext) {
+			limitadorObj = basicLimitador(testNamespace)
+			limitadorObj.Spec.Limits = limits
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(limitadorObj)).WithContext(ctx).Should(BeTrue())
+		}, nodeTimeOut)
+
+		It("Should annotate limitador pods with annotation of limits hash", func(ctx SpecContext) {
+			podList := &corev1.PodList{}
+			options := &client.ListOptions{
+				LabelSelector: labels.SelectorFromSet(limitador.Labels(limitadorObj)),
+				Namespace:     limitadorObj.Namespace,
+			}
+			Eventually(k8sClient.List(ctx, podList, options)).WithContext(ctx).Should(BeNil())
+
+			hash, err := limitadorObj.LimitsHash()
+			Expect(err).To(BeNil())
+			Expect(podList.Items).To(HaveLen(int(limitadorv1alpha1.DefaultReplicas)))
+			for _, pod := range podList.Items {
+				Expect(pod.Annotations[limitadorv1alpha1.PodAnnotationLimitsHash]).To(Equal(hash))
+			}
+		}, specTimeOut)
+	})
+
+	Context("Updating a Limitador object - multiple replicas", func() {
+		var (
+			limitadorObj *limitadorv1alpha1.Limitador
+			replicas     = 3
+		)
+
+		limit1 := limitadorv1alpha1.RateLimit{
+			Conditions: []string{"req.method == 'GET'"},
+			MaxValue:   10,
+			Namespace:  "test-namespace",
+			Seconds:    60,
+			Variables:  []string{"user_id"},
+			Name:       "useless",
+		}
+		limits := []limitadorv1alpha1.RateLimit{limit1}
+		updatedLimits := []limitadorv1alpha1.RateLimit{
+			limit1,
+			{
+				Conditions: []string{"req.method == 'POST'"},
+				MaxValue:   5,
+				Namespace:  "test-namespace",
+				Seconds:    60,
+				Variables:  []string{"user_id"},
+			},
+		}
+
+		BeforeEach(func(ctx SpecContext) {
+			limitadorObj = basicLimitador(testNamespace)
+			limitadorObj.Spec.Replicas = &replicas
+			limitadorObj.Spec.Limits = limits
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(limitadorObj)).WithContext(ctx).Should(BeTrue())
+		}, nodeTimeOut)
+
+		It("Should update limitador pods annotation and sync config map to pod", func(ctx SpecContext) {
+			// Check hash of pods before update
+			podList := &corev1.PodList{}
+			options := &client.ListOptions{
+				LabelSelector: labels.SelectorFromSet(limitador.Labels(limitadorObj)),
+				Namespace:     limitadorObj.Namespace,
+			}
+			Eventually(k8sClient.List(ctx, podList, options)).WithContext(ctx).Should(BeNil())
+
+			hash, err := limitadorObj.LimitsHash()
+			Expect(err).To(BeNil())
+			Expect(podList.Items).To(HaveLen(replicas))
+			for _, pod := range podList.Items {
+				Expect(pod.Annotations[limitadorv1alpha1.PodAnnotationLimitsHash]).To(Equal(hash))
+			}
+
+			// Update limitador with new limits
+			updatedLimitador := limitadorv1alpha1.Limitador{}
+			Eventually(func(g Gomega) error {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: testNamespace,
+					Name:      limitadorObj.Name,
+				}, &updatedLimitador)
+				g.Expect(err).To(BeNil())
+
+				updatedLimitador.Spec.Limits = updatedLimits
+
+				return k8sClient.Update(ctx, &updatedLimitador)
+			}).WithContext(ctx).Should(BeNil())
+
+			// Hash should be updated
+			hash, err = updatedLimitador.LimitsHash()
+			Expect(err).To(BeNil())
+			Eventually(func(g Gomega) error {
+				err := k8sClient.List(ctx, podList, options)
+				g.Expect(err).To(BeNil())
+				g.Expect(podList.Items).To(Not(BeEmpty()))
+
+				for _, pod := range podList.Items {
+					g.Expect(pod.Annotations[limitadorv1alpha1.PodAnnotationLimitsHash]).To(Equal(hash))
+				}
+				return nil
+			}).WithContext(ctx).Should(BeNil())
+
+			// Config map should be synced immediately if pod annotations was updated successfully
+			config, err := config.GetConfig()
+			Expect(err).To(BeNil())
+			clientSet, err := kubernetes.NewForConfig(config)
+			Expect(err).To(BeNil())
+
+			// Name of the pod where the function will be executed.
+			podName := podList.Items[0].Name
+
+			// Command to execute your function.
+			command := []string{"cat", fmt.Sprintf("%s/%s", limitador.LimitadorCMMountPath, limitador.LimitadorConfigFileName)}
+
+			Eventually(func(g Gomega) {
+				req := clientSet.CoreV1().
+					RESTClient().
+					Post().
+					Resource("pods").
+					Name(podName).
+					Namespace(limitadorObj.Namespace).
+					SubResource("exec")
+
+				option := &corev1.PodExecOptions{
+					Command:   command,
+					Stdin:     false,
+					Stdout:    true,
+					Stderr:    true,
+					TTY:       true,
+					Container: "limitador",
+				}
+				req.VersionedParams(
+					option,
+					scheme.ParameterCodec,
+				)
+
+				// Create an executor.
+				executor, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+				g.Expect(err).To(BeNil())
+
+				// Create buffers to capture stdout and stderr.
+				var stdout, stderr bytes.Buffer
+
+				// Create a StreamOptions struct.
+				streamOptions := remotecommand.StreamOptions{
+					Stdout: &stdout,
+					Stderr: &stderr,
+				}
+
+				// Execute the function within the pod.
+				err = executor.StreamWithContext(ctx, streamOptions)
+				g.Expect(err).To(BeNil())
+				g.Expect(stderr.String()).To(BeEmpty())
+
+				// Get the config map
+				configmap := corev1.ConfigMap{}
+				if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: limitadorObj.Namespace, Name: limitador.LimitsConfigMapName(limitadorObj)}, &configmap); err != nil {
+					g.Expect(err).To(BeNil())
+				}
+
+				configmapData := configmap.Data[limitador.LimitadorConfigFileName]
+				// There might be line break differences
+				configmapInPod := strings.ReplaceAll(stdout.String(), "\r\n", "\n")
+				g.Expect(configmapData).To(Equal(configmapInPod))
+			}).WithContext(ctx).Should(Succeed())
+		}, specTimeOut)
+	})
+})

--- a/controllers/limitador_controller_ports_test.go
+++ b/controllers/limitador_controller_ports_test.go
@@ -1,14 +1,11 @@
 package controllers
 
 import (
-	"context"
-	"reflect"
 	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"golang.org/x/exp/slices"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -20,14 +17,20 @@ import (
 )
 
 var _ = Describe("Limitador controller manages ports", func() {
+	const (
+		nodeTimeOut = NodeTimeout(time.Second * 30)
+		specTimeOut = SpecTimeout(time.Minute * 2)
+	)
 
 	var testNamespace string
 
-	BeforeEach(func() {
-		CreateNamespace(&testNamespace)
-	})
+	BeforeEach(func(ctx SpecContext) {
+		CreateNamespaceWithContext(ctx, &testNamespace)
+	}, nodeTimeOut)
 
-	AfterEach(DeleteNamespaceCallback(&testNamespace))
+	AfterEach(func(ctx SpecContext) {
+		DeleteNamespaceWithContext(ctx, &testNamespace)
+	}, nodeTimeOut)
 
 	Context("Creating a new Limitador object with specific ports", func() {
 		var limitadorObj *limitadorv1alpha1.Limitador
@@ -38,16 +41,16 @@ var _ = Describe("Limitador controller manages ports", func() {
 		httpPort := &limitadorv1alpha1.TransportProtocol{Port: &httpPortNumber}
 		grpcPort := &limitadorv1alpha1.TransportProtocol{Port: &grpcPortNumber}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			limitadorObj = basicLimitador(testNamespace)
 			limitadorObj.Spec.Listener = &limitadorv1alpha1.Listener{
 				HTTP: httpPort, GRPC: grpcPort,
 			}
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
-		})
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
+		}, nodeTimeOut)
 
-		It("Should configure k8s resources with the custom ports", func() {
+		It("Should configure k8s resources with the custom ports", func(ctx SpecContext) {
 			// Deployment ports
 			// Deployment command line
 			// Deployment probes
@@ -55,17 +58,15 @@ var _ = Describe("Limitador controller manages ports", func() {
 			// Service
 
 			deployment := appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(
-					context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(
+					ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
 					},
-					&deployment)
-
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+					&deployment)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 			Expect(deployment.Spec.Template.Spec.Containers[0].Ports).To(ContainElements(
@@ -102,7 +103,7 @@ var _ = Describe("Limitador controller manages ports", func() {
 				ProbeHandler.HTTPGet.Port).To(Equal(intstr.FromInt(int(httpPortNumber))))
 
 			limitadorCR := &limitadorv1alpha1.Limitador{}
-			err := k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(limitadorObj), limitadorCR)
+			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(limitadorObj), limitadorCR)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(limitadorCR.Status.Service).NotTo(BeNil())
 			Expect(limitadorCR.Status.Service.Ports).To(Equal(
@@ -110,7 +111,7 @@ var _ = Describe("Limitador controller manages ports", func() {
 			))
 
 			service := &v1.Service{}
-			err = k8sClient.Get(context.TODO(), types.NamespacedName{
+			err = k8sClient.Get(ctx, types.NamespacedName{
 				Namespace: testNamespace,
 				Name:      limitador.ServiceName(limitadorObj),
 			}, service)
@@ -125,7 +126,7 @@ var _ = Describe("Limitador controller manages ports", func() {
 					TargetPort: intstr.FromString("grpc"),
 				},
 			))
-		})
+		}, specTimeOut)
 	})
 
 	Context("Updating limitador object with new custom ports", func() {
@@ -137,22 +138,20 @@ var _ = Describe("Limitador controller manages ports", func() {
 		httpPort := &limitadorv1alpha1.TransportProtocol{Port: &httpPortNumber}
 		grpcPort := &limitadorv1alpha1.TransportProtocol{Port: &grpcPortNumber}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			limitadorObj = basicLimitador(testNamespace)
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
-		})
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
+		}, nodeTimeOut)
 
-		It("Should modify the k8s resources with the custom ports", func() {
+		It("Should modify the k8s resources with the custom ports", func(ctx SpecContext) {
 			deployment := appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(), types.NamespacedName{
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
 					Namespace: testNamespace,
 					Name:      limitador.DeploymentName(limitadorObj),
-				}, &deployment)
-
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+				}, &deployment)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 			Expect(deployment.Spec.Template.Spec.Containers[0].Ports).To(ContainElements(
@@ -193,7 +192,7 @@ var _ = Describe("Limitador controller manages ports", func() {
 			))
 
 			limitadorCR := &limitadorv1alpha1.Limitador{}
-			err := k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(limitadorObj), limitadorCR)
+			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(limitadorObj), limitadorCR)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(limitadorCR.Status.Service).NotTo(BeNil())
 			Expect(limitadorCR.Status.Service.Ports).To(Equal(
@@ -204,7 +203,7 @@ var _ = Describe("Limitador controller manages ports", func() {
 			))
 
 			service := &v1.Service{}
-			err = k8sClient.Get(context.TODO(), types.NamespacedName{
+			err = k8sClient.Get(ctx, types.NamespacedName{
 				Namespace: testNamespace,
 				Name:      limitador.ServiceName(limitadorObj),
 			}, service)
@@ -222,104 +221,71 @@ var _ = Describe("Limitador controller manages ports", func() {
 
 			// Let's update limitador CR
 			updatedLimitador := limitadorv1alpha1.Limitador{}
-			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(), types.NamespacedName{
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
 					Namespace: testNamespace, Name: limitadorObj.Name,
-				}, &updatedLimitador)
-
-				if err != nil {
-					return false
-				}
+				}, &updatedLimitador)).To(Succeed())
 
 				updatedLimitador.Spec.Listener = &limitadorv1alpha1.Listener{
 					HTTP: httpPort, GRPC: grpcPort,
 				}
 
-				return k8sClient.Update(context.TODO(), &updatedLimitador) == nil
-			}, timeout, interval).Should(BeTrue())
+				g.Expect(k8sClient.Update(ctx, &updatedLimitador)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				newDeployment := appsv1.Deployment{}
-				err := k8sClient.Get(context.TODO(), types.NamespacedName{
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
 					Namespace: testNamespace,
 					Name:      limitador.DeploymentName(limitadorObj),
-				}, &newDeployment)
+				}, &newDeployment)).To(Succeed())
 
-				if err != nil {
-					return false
-				}
+				g.Expect(newDeployment.Spec.Template.Spec.Containers[0].Ports).To(ContainElements(v1.ContainerPort{
+					Name: "http", ContainerPort: httpPortNumber, Protocol: v1.ProtocolTCP,
+				}))
 
-				httpPortsMatch := slices.Index(newDeployment.Spec.Template.Spec.Containers[0].Ports,
-					v1.ContainerPort{
-						Name: "http", ContainerPort: httpPortNumber, Protocol: v1.ProtocolTCP,
-					}) != -1
+				g.Expect(newDeployment.Spec.Template.Spec.Containers[0].Ports).To(ContainElements(v1.ContainerPort{
+					Name: "grpc", ContainerPort: grpcPortNumber, Protocol: v1.ProtocolTCP,
+				}))
 
-				grpcPortsMatch := slices.Index(newDeployment.Spec.Template.Spec.Containers[0].Ports,
-					v1.ContainerPort{
-						Name: "grpc", ContainerPort: grpcPortNumber, Protocol: v1.ProtocolTCP,
-					}) != -1
-				commandMatch := reflect.DeepEqual(newDeployment.Spec.Template.Spec.Containers[0].Command,
-					[]string{
-						"limitador-server",
-						"--http-port",
-						strconv.Itoa(int(httpPortNumber)),
-						"--rls-port",
-						strconv.Itoa(int(grpcPortNumber)),
-						"/home/limitador/etc/limitador-config.yaml",
-						"memory",
-					})
-				livenessProbeMatch := reflect.DeepEqual(newDeployment.Spec.Template.Spec.Containers[0].LivenessProbe.
-					ProbeHandler.HTTPGet.Port, intstr.FromInt(int(httpPortNumber)))
-				readinessProbeMatch := reflect.DeepEqual(newDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe.
-					ProbeHandler.HTTPGet.Port, intstr.FromInt(int(httpPortNumber)))
+				g.Expect(newDeployment.Spec.Template.Spec.Containers[0].Command).To(Equal([]string{
+					"limitador-server",
+					"--http-port",
+					strconv.Itoa(int(httpPortNumber)),
+					"--rls-port",
+					strconv.Itoa(int(grpcPortNumber)),
+					"/home/limitador/etc/limitador-config.yaml",
+					"memory",
+				}))
 
-				return !slices.Contains(
-					[]bool{
-						httpPortsMatch, grpcPortsMatch, commandMatch,
-						livenessProbeMatch, readinessProbeMatch,
-					}, false)
-			}, timeout, interval).Should(BeTrue())
+				g.Expect(newDeployment.Spec.Template.Spec.Containers[0].LivenessProbe.ProbeHandler.HTTPGet.Port).To(Equal(intstr.FromInt32(httpPortNumber)))
+				g.Expect(newDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe.ProbeHandler.HTTPGet.Port).To(Equal(intstr.FromInt32(httpPortNumber)))
+			}).WithContext(ctx).Should(Succeed())
 
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				newLimitador := &limitadorv1alpha1.Limitador{}
-				err := k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(limitadorObj), newLimitador)
-				if err != nil {
-					return false
-				}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(limitadorObj), newLimitador)).To(Succeed())
+				g.Expect(newLimitador.Status.Service).NotTo(BeNil())
+				g.Expect(newLimitador.Status.Service.Ports).To(Equal(limitadorv1alpha1.Ports{GRPC: grpcPortNumber, HTTP: httpPortNumber}))
+			}).WithContext(ctx).Should(Succeed())
 
-				if newLimitador.Status.Service == nil {
-					return false
-				}
-				return reflect.DeepEqual(newLimitador.Status.Service.Ports,
-					limitadorv1alpha1.Ports{GRPC: grpcPortNumber, HTTP: httpPortNumber},
-				)
-			}, timeout, interval).Should(BeTrue())
-
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				newService := &v1.Service{}
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
 					Namespace: testNamespace,
 					Name:      limitador.ServiceName(limitadorObj),
-				}, newService)
+				}, newService)).To(Succeed())
 
-				if err != nil {
-					return false
-				}
+				g.Expect(newService.Spec.Ports).To(ContainElements(v1.ServicePort{
+					Name: "http", Port: httpPortNumber, Protocol: v1.ProtocolTCP,
+					TargetPort: intstr.FromString("http"),
+				}))
 
-				httpPortsMatch := slices.Index(newService.Spec.Ports,
-					v1.ServicePort{
-						Name: "http", Port: httpPortNumber, Protocol: v1.ProtocolTCP,
-						TargetPort: intstr.FromString("http"),
-					}) != -1
-
-				grpcPortsMatch := slices.Index(newService.Spec.Ports,
-					v1.ServicePort{
-						Name: "grpc", Port: grpcPortNumber, Protocol: v1.ProtocolTCP,
-						TargetPort: intstr.FromString("grpc"),
-					}) != -1
-
-				return !slices.Contains([]bool{httpPortsMatch, grpcPortsMatch}, false)
-			}, timeout, interval).Should(BeTrue())
-		})
+				g.Expect(newService.Spec.Ports).To(ContainElements(v1.ServicePort{
+					Name: "grpc", Port: grpcPortNumber, Protocol: v1.ProtocolTCP,
+					TargetPort: intstr.FromString("grpc"),
+				}))
+			}).WithContext(ctx).Should(Succeed())
+		}, specTimeOut)
 	})
 })

--- a/controllers/limitador_controller_replicas_test.go
+++ b/controllers/limitador_controller_replicas_test.go
@@ -1,55 +1,57 @@
 package controllers
 
 import (
-	"context"
-	"reflect"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 	"github.com/kuadrant/limitador-operator/pkg/limitador"
 )
 
 var _ = Describe("Limitador controller manages replicas", func() {
-
+	const (
+		nodeTimeOut = NodeTimeout(time.Second * 30)
+		specTimeOut = SpecTimeout(time.Minute * 2)
+	)
 	var testNamespace string
 
-	BeforeEach(func() {
-		CreateNamespace(&testNamespace)
-	})
+	BeforeEach(func(ctx SpecContext) {
+		CreateNamespaceWithContext(ctx, &testNamespace)
+	}, nodeTimeOut)
 
-	AfterEach(DeleteNamespaceCallback(&testNamespace))
+	AfterEach(func(ctx SpecContext) {
+		DeleteNamespaceWithContext(ctx, &testNamespace)
+	}, nodeTimeOut)
 
 	Context("Creating a new Limitador object with specific replicas", func() {
 		var limitadorObj *limitadorv1alpha1.Limitador
 
 		var replicas int32 = 2
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			limitadorObj = basicLimitador(testNamespace)
-			limitadorObj.Spec.Replicas = &[]int{int(replicas)}[0]
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
-		})
+			limitadorObj.Spec.Replicas = ptr.To(int(replicas))
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
+		}, nodeTimeOut)
 
-		It("Should create a new deployment with the custom replicas", func() {
+		It("Should create a new deployment with the custom replicas", func(ctx SpecContext) {
 			deployment := appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
-					}, &deployment)
-
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+					}, &deployment)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			Expect(*deployment.Spec.Replicas).To(Equal(replicas))
-		})
+		}, specTimeOut)
 	})
 
 	Context("Updating limitador object with new replicas", func() {
@@ -57,56 +59,46 @@ var _ = Describe("Limitador controller manages replicas", func() {
 
 		var replicas int32 = 2
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			limitadorObj = basicLimitador(testNamespace)
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
-		})
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj), time.Minute, 5*time.Second).Should(Succeed())
+		}, nodeTimeOut)
 
-		It("Should modify deployment replicas", func() {
+		It("Should modify deployment replicas", func(ctx SpecContext) {
 			deployment := appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
-					}, &deployment)
-
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+					}, &deployment)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
 
 			updatedLimitador := limitadorv1alpha1.Limitador{}
-			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(), types.NamespacedName{
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
 					Namespace: testNamespace,
 					Name:      limitadorObj.Name,
-				}, &updatedLimitador)
+				}, &updatedLimitador)).To(Succeed())
 
-				if err != nil {
-					return false
-				}
+				updatedLimitador.Spec.Replicas = ptr.To(int(replicas))
 
-				updatedLimitador.Spec.Replicas = &[]int{int(replicas)}[0]
+				g.Expect(k8sClient.Update(ctx, &updatedLimitador)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
-				return k8sClient.Update(context.TODO(), &updatedLimitador) == nil
-			}, timeout, interval).Should(BeTrue())
-
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				newDeployment := &appsv1.Deployment{}
-				err := k8sClient.Get(context.TODO(),
+				g.Expect(k8sClient.Get(ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
-					}, newDeployment)
+					}, newDeployment)).To(Succeed())
 
-				if err != nil {
-					return false
-				}
-
-				return reflect.DeepEqual(*newDeployment.Spec.Replicas, replicas)
-			}, timeout, interval).Should(BeTrue())
-		})
+				g.Expect(*newDeployment.Spec.Replicas).To(Equal(replicas))
+			}).WithContext(ctx).Should(Succeed())
+		}, specTimeOut)
 	})
 })

--- a/controllers/limitador_controller_resources_test.go
+++ b/controllers/limitador_controller_resources_test.go
@@ -1,8 +1,6 @@
 package controllers
 
 import (
-	"context"
-	"reflect"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -17,14 +15,19 @@ import (
 )
 
 var _ = Describe("Limitador controller manages resource requirements", func() {
-
+	const (
+		nodeTimeOut = NodeTimeout(time.Second * 30)
+		specTimeOut = SpecTimeout(time.Minute * 2)
+	)
 	var testNamespace string
 
-	BeforeEach(func() {
-		CreateNamespace(&testNamespace)
-	})
+	BeforeEach(func(ctx SpecContext) {
+		CreateNamespaceWithContext(ctx, &testNamespace)
+	}, nodeTimeOut)
 
-	AfterEach(DeleteNamespaceCallback(&testNamespace))
+	AfterEach(func(ctx SpecContext) {
+		DeleteNamespaceWithContext(ctx, &testNamespace)
+	}, nodeTimeOut)
 
 	Context("Creating a new Limitador object with specific resource requirements", func() {
 		var limitadorObj *limitadorv1alpha1.Limitador
@@ -33,29 +36,27 @@ var _ = Describe("Limitador controller manages resource requirements", func() {
 		// which is different from the default resource requirements
 		resourceRequirements := v1.ResourceRequirements{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			limitadorObj = basicLimitador(testNamespace)
 			limitadorObj.Spec.ResourceRequirements = &resourceRequirements
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
-		})
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
+		}, nodeTimeOut)
 
-		It("Should create a new deployment with the custom resource requirements", func() {
+		It("Should create a new deployment with the custom resource requirements", func(ctx SpecContext) {
 			deployment := appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
-					}, &deployment)
-
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+					}, &deployment)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 			Expect(deployment.Spec.Template.Spec.Containers[0].Resources).To(
 				Equal(resourceRequirements))
-		})
+		}, specTimeOut)
 	})
 
 	Context("Updating limitador object with new resource requirements", func() {
@@ -65,23 +66,21 @@ var _ = Describe("Limitador controller manages resource requirements", func() {
 		// which is different from the default resource requirements
 		resourceRequirements := v1.ResourceRequirements{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			limitadorObj = basicLimitador(testNamespace)
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
-		})
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
+		}, nodeTimeOut)
 
-		It("Should modify deployment resource requirements", func() {
+		It("Should modify deployment resource requirements", func(ctx SpecContext) {
 			deployment := appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
-					}, &deployment)
-
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+					}, &deployment)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			expectedDefaultResourceRequirements := v1.ResourceRequirements{
 				Requests: v1.ResourceList{
@@ -100,39 +99,26 @@ var _ = Describe("Limitador controller manages resource requirements", func() {
 			))
 
 			updatedLimitador := limitadorv1alpha1.Limitador{}
-			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(), types.NamespacedName{
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
 					Namespace: testNamespace,
 					Name:      limitadorObj.Name,
-				}, &updatedLimitador)
-
-				if err != nil {
-					return false
-				}
+				}, &updatedLimitador)).To(Succeed())
 
 				updatedLimitador.Spec.ResourceRequirements = &resourceRequirements
 
-				return k8sClient.Update(context.TODO(), &updatedLimitador) == nil
-			}, timeout, interval).Should(BeTrue())
+				g.Expect(k8sClient.Update(ctx, &updatedLimitador)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				newDeployment := &appsv1.Deployment{}
-				err := k8sClient.Get(context.TODO(),
+				g.Expect(k8sClient.Get(ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
-					}, newDeployment)
-
-				if err != nil {
-					return false
-				}
-
-				if len(newDeployment.Spec.Template.Spec.Containers) < 1 {
-					return false
-				}
-
-				return reflect.DeepEqual(newDeployment.Spec.Template.Spec.Containers[0].Resources, resourceRequirements)
-			}, timeout, interval).Should(BeTrue())
-		})
+					}, newDeployment)).Should(Succeed())
+				g.Expect(newDeployment.Spec.Template.Spec.Containers[0].Resources).To(Equal(resourceRequirements))
+			}).WithContext(ctx).Should(Succeed())
+		}, specTimeOut)
 	})
 })

--- a/controllers/limitador_controller_test.go
+++ b/controllers/limitador_controller_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -56,7 +56,7 @@ var _ = Describe("Limitador controller", func() {
 		})
 
 		It("Should create a Limitador service with default ports", func() {
-			createdLimitadorService := v1.Service{}
+			createdLimitadorService := corev1.Service{}
 			Eventually(func() bool {
 				err := k8sClient.Get(
 					context.TODO(),
@@ -76,14 +76,14 @@ var _ = Describe("Limitador controller", func() {
 
 		It("Should create a new deployment with default settings", func() {
 			var expectedDefaultReplicas int32 = 1
-			expectedDefaultResourceRequirements := v1.ResourceRequirements{
-				Requests: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("250m"),
-					v1.ResourceMemory: resource.MustParse("32Mi"),
+			expectedDefaultResourceRequirements := corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("250m"),
+					corev1.ResourceMemory: resource.MustParse("32Mi"),
 				},
-				Limits: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("500m"),
-					v1.ResourceMemory: resource.MustParse("64Mi"),
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("64Mi"),
 				},
 			}
 
@@ -152,7 +152,7 @@ var _ = Describe("Limitador controller", func() {
 		})
 
 		It("Should create a ConfigMap with empty limits", func() {
-			createdConfigMap := v1.ConfigMap{}
+			createdConfigMap := corev1.ConfigMap{}
 			Eventually(func() bool {
 				err := k8sClient.Get(
 					context.TODO(),
@@ -496,7 +496,7 @@ var _ = Describe("Limitador controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(deploymentObj.Spec.Template.Spec.Containers).To(HaveLen(1))
-			containerObj := v1.Container{Name: "newcontainer", Image: "someImage"}
+			containerObj := corev1.Container{Name: "newcontainer", Image: "someImage"}
 
 			deploymentObj.Spec.Template.Spec.Containers = append(deploymentObj.Spec.Template.Spec.Containers, containerObj)
 
@@ -530,25 +530,25 @@ var _ = Describe("Limitador controller", func() {
 	})
 
 	Context("Deploying limitador object with redis storage", func() {
-		var redisSecret *v1.Secret
+		var redisSecret *corev1.Secret
 
 		BeforeEach(func() {
 			deployRedis(testNamespace)
 
-			redisSecret = &v1.Secret{
+			redisSecret = &corev1.Secret{
 				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
 				ObjectMeta: metav1.ObjectMeta{Name: "redis", Namespace: testNamespace},
 				StringData: map[string]string{
 					"URL": fmt.Sprintf("redis://%s.%s.svc.cluster.local:6379", redisService(testNamespace).Name, testNamespace),
 				},
-				Type: v1.SecretTypeOpaque,
+				Type: corev1.SecretTypeOpaque,
 			}
 
 			err := k8sClient.Create(context.Background(), redisSecret)
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() bool {
-				secret := &v1.Secret{}
+				secret := &corev1.Secret{}
 				err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(redisSecret), secret)
 				if err != nil {
 					if apierrors.IsNotFound(err) {
@@ -599,25 +599,25 @@ var _ = Describe("Limitador controller", func() {
 	})
 
 	Context("Deploying limitador object with redis cached storage", func() {
-		var redisSecret *v1.Secret
+		var redisSecret *corev1.Secret
 
 		BeforeEach(func() {
 			deployRedis(testNamespace)
 
-			redisSecret = &v1.Secret{
+			redisSecret = &corev1.Secret{
 				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
 				ObjectMeta: metav1.ObjectMeta{Name: "redis", Namespace: testNamespace},
 				StringData: map[string]string{
 					"URL": fmt.Sprintf("redis://%s.%s.svc.cluster.local:6379", redisService(testNamespace).Name, testNamespace),
 				},
-				Type: v1.SecretTypeOpaque,
+				Type: corev1.SecretTypeOpaque,
 			}
 
 			err := k8sClient.Create(context.Background(), redisSecret)
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() bool {
-				secret := &v1.Secret{}
+				secret := &corev1.Secret{}
 				err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(redisSecret), secret)
 				if err != nil {
 					if apierrors.IsNotFound(err) {
@@ -736,10 +736,10 @@ var _ = Describe("Limitador controller", func() {
 			Expect(deploymentObj.Spec.Template.Spec.Volumes).To(HaveLen(2))
 			Expect(deploymentObj.Spec.Template.Spec.Volumes[1]).To(
 				Equal(
-					v1.Volume{
+					corev1.Volume{
 						Name: limitador.DiskVolumeName,
-						VolumeSource: v1.VolumeSource{
-							PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 								ClaimName: limitador.PVCName(limitadorObj),
 								ReadOnly:  false,
 							},
@@ -763,7 +763,7 @@ var _ = Describe("Limitador controller", func() {
 			Expect(deploymentObj.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(2))
 			Expect(deploymentObj.Spec.Template.Spec.Containers[0].VolumeMounts[1]).To(
 				Equal(
-					v1.VolumeMount{
+					corev1.VolumeMount{
 						ReadOnly:  false,
 						Name:      limitador.DiskVolumeName,
 						MountPath: limitador.DiskPath,
@@ -777,7 +777,7 @@ var _ = Describe("Limitador controller", func() {
 			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
 			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
 
-			pvc := &v1.PersistentVolumeClaim{}
+			pvc := &corev1.PersistentVolumeClaim{}
 			Eventually(func() bool {
 				err := k8sClient.Get(
 					context.TODO(),
@@ -816,7 +816,7 @@ func limitadorWithRedisStorage(redisKey client.ObjectKey, ns string) *limitadorv
 		Spec: limitadorv1alpha1.LimitadorSpec{
 			Storage: &limitadorv1alpha1.Storage{
 				Redis: &limitadorv1alpha1.Redis{
-					ConfigSecretRef: &v1.LocalObjectReference{
+					ConfigSecretRef: &corev1.LocalObjectReference{
 						Name: redisKey.Name,
 					},
 				},
@@ -832,7 +832,7 @@ func limitadorWithRedisCachedStorage(key client.ObjectKey, ns string) *limitador
 		Spec: limitadorv1alpha1.LimitadorSpec{
 			Storage: &limitadorv1alpha1.Storage{
 				RedisCached: &limitadorv1alpha1.RedisCached{
-					ConfigSecretRef: &v1.LocalObjectReference{
+					ConfigSecretRef: &corev1.LocalObjectReference{
 						Name: key.Name,
 					},
 				},
@@ -878,7 +878,7 @@ func deployRedis(ns string) {
 	service := redisService(ns)
 	Expect(k8sClient.Create(context.TODO(), service)).Should(Succeed())
 	Eventually(func() bool {
-		s := &v1.Service{}
+		s := &corev1.Service{}
 		err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(service), s)
 		return err == nil
 	}, timeout, interval).Should(BeTrue())
@@ -896,31 +896,31 @@ func redisDeployment(ns string) *appsv1.Deployment {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": "redis"},
 			},
-			Template: v1.PodTemplateSpec{
+			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"app": "redis"},
 				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{{Name: "redis", Image: "redis"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "redis", Image: "redis"}},
 				},
 			},
 		},
 	}
 }
 
-func redisService(ns string) *v1.Service {
-	return &v1.Service{
+func redisService(ns string) *corev1.Service {
+	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "redis",
 			Namespace: ns,
 		},
-		Spec: v1.ServiceSpec{
+		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{"app": "redis"},
-			Ports: []v1.ServicePort{
+			Ports: []corev1.ServicePort{
 				{
 					Name:       "redis",
-					Protocol:   v1.ProtocolTCP,
+					Protocol:   corev1.ProtocolTCP,
 					Port:       6379,
 					TargetPort: intstr.FromInt(6379),
 				},
@@ -940,7 +940,7 @@ func testLimitadorIsReady(l *limitadorv1alpha1.Limitador) func() bool {
 func CreateNamespace(namespace *string) {
 	var generatedTestNamespace = "test-namespace-" + string(uuid.NewUUID())
 
-	nsObject := &v1.Namespace{
+	nsObject := &corev1.Namespace{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"},
 		ObjectMeta: metav1.ObjectMeta{Name: generatedTestNamespace},
 	}
@@ -948,7 +948,7 @@ func CreateNamespace(namespace *string) {
 	err := k8sClient.Create(context.Background(), nsObject)
 	Expect(err).ToNot(HaveOccurred())
 
-	existingNamespace := &v1.Namespace{}
+	existingNamespace := &corev1.Namespace{}
 	Eventually(func() bool {
 		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: generatedTestNamespace}, existingNamespace)
 		return err == nil
@@ -957,14 +957,32 @@ func CreateNamespace(namespace *string) {
 	*namespace = existingNamespace.Name
 }
 
+func CreateNamespaceWithContext(ctx context.Context, namespace *string) {
+	nsObject := &corev1.Namespace{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"},
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "test-namespace-"},
+	}
+	Expect(k8sClient.Create(ctx, nsObject)).ToNot(HaveOccurred())
+
+	*namespace = nsObject.Name
+}
+
+func DeleteNamespaceWithContext(ctx context.Context, namespace *string) {
+	desiredTestNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: *namespace}}
+	Eventually(func() bool {
+		err := k8sClient.Delete(ctx, desiredTestNamespace, client.PropagationPolicy(metav1.DeletePropagationForeground))
+		return err != nil && apierrors.IsNotFound(err)
+	}).WithContext(ctx).Should(BeTrue())
+}
+
 func DeleteNamespaceCallback(namespace *string) func() {
 	return func() {
-		desiredTestNamespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: *namespace}}
+		desiredTestNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: *namespace}}
 		err := k8sClient.Delete(context.Background(), desiredTestNamespace, client.PropagationPolicy(metav1.DeletePropagationForeground))
 
 		Expect(err).ToNot(HaveOccurred())
 
-		existingNamespace := &v1.Namespace{}
+		existingNamespace := &corev1.Namespace{}
 		Eventually(func() bool {
 			err := k8sClient.Get(context.Background(), types.NamespacedName{Name: *namespace}, existingNamespace)
 			if err != nil && apierrors.IsNotFound(err) {

--- a/controllers/limitador_controller_test.go
+++ b/controllers/limitador_controller_test.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strconv"
 	"time"
 
@@ -18,7 +17,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
@@ -27,54 +25,53 @@ import (
 	"github.com/kuadrant/limitador-operator/pkg/limitador"
 )
 
-const (
-	timeout  = time.Second * 10
-	interval = time.Millisecond * 250
-)
-
 var (
 	ExpectedDefaultImage = fmt.Sprintf("%s:%s", limitador.LimitadorRepository, "latest")
 )
 
 var _ = Describe("Limitador controller", func() {
-
+	const (
+		nodeTimeOut = NodeTimeout(time.Second * 30)
+		specTimeOut = SpecTimeout(time.Minute * 2)
+	)
 	var testNamespace string
 
-	BeforeEach(func() {
-		CreateNamespace(&testNamespace)
-	})
+	BeforeEach(func(ctx SpecContext) {
+		CreateNamespaceWithContext(ctx, &testNamespace)
+	}, nodeTimeOut)
 
-	AfterEach(DeleteNamespaceCallback(&testNamespace))
+	AfterEach(func(ctx SpecContext) {
+		DeleteNamespaceWithContext(ctx, &testNamespace)
+	}, nodeTimeOut)
 
 	Context("Creating a new basic limitador CR", func() {
 		var limitadorObj *limitadorv1alpha1.Limitador
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			limitadorObj = basicLimitador(testNamespace)
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
-		})
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
+		}, nodeTimeOut)
 
-		It("Should create a Limitador service with default ports", func() {
+		It("Should create a Limitador service with default ports", func(ctx SpecContext) {
 			createdLimitadorService := corev1.Service{}
-			Eventually(func() bool {
-				err := k8sClient.Get(
-					context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(
+					ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.ServiceName(limitadorObj),
 					},
-					&createdLimitadorService)
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+					&createdLimitadorService)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 			Expect(createdLimitadorService.Spec.Ports).To(HaveLen(2))
 			Expect(createdLimitadorService.Spec.Ports[0].Name).Should(Equal("http"))
 			Expect(createdLimitadorService.Spec.Ports[0].Port).Should(Equal(limitadorv1alpha1.DefaultServiceHTTPPort))
 			Expect(createdLimitadorService.Spec.Ports[1].Name).Should(Equal("grpc"))
 			Expect(createdLimitadorService.Spec.Ports[1].Port).Should(Equal(limitadorv1alpha1.DefaultServiceGRPCPort))
-		})
+		}, specTimeOut)
 
-		It("Should create a new deployment with default settings", func() {
+		It("Should create a new deployment with default settings", func(ctx SpecContext) {
 			var expectedDefaultReplicas int32 = 1
 			expectedDefaultResourceRequirements := corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
@@ -88,17 +85,15 @@ var _ = Describe("Limitador controller", func() {
 			}
 
 			createdLimitadorDeployment := appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(
-					context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(
+					ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
 					},
-					&createdLimitadorDeployment)
-
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+					&createdLimitadorDeployment)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			Expect(*createdLimitadorDeployment.Spec.Replicas).Should(Equal(expectedDefaultReplicas))
 			Expect(createdLimitadorDeployment.Spec.Template.Spec.Containers).To(HaveLen(1))
@@ -126,87 +121,80 @@ var _ = Describe("Limitador controller", func() {
 			Expect(createdLimitadorDeployment.Spec.Template.Spec.Containers[0].Resources).To(
 				Equal(expectedDefaultResourceRequirements))
 			Expect(createdLimitadorDeployment.Spec.Template.Spec.Affinity).To(BeNil())
-		})
+		}, specTimeOut)
 
-		It("Should build the correct Status", func() {
+		It("Should build the correct Status", func(ctx SpecContext) {
 			createdLimitador := limitadorv1alpha1.Limitador{}
-			Eventually(func() *limitadorv1alpha1.LimitadorService {
-				err := k8sClient.Get(
-					context.TODO(),
+			Eventually(func(g Gomega) *limitadorv1alpha1.LimitadorService {
+				g.Expect(k8sClient.Get(
+					ctx,
 					types.NamespacedName{
 						Namespace: limitadorObj.Namespace,
 						Name:      limitadorObj.Name,
 					},
-					&createdLimitador)
-				if err != nil {
-					return nil
-				}
+					&createdLimitador)).To(Succeed())
 				return createdLimitador.Status.Service
-			}, timeout, interval).Should(Equal(&limitadorv1alpha1.LimitadorService{
+			}).WithContext(ctx).Should(Equal(&limitadorv1alpha1.LimitadorService{
 				Host: fmt.Sprintf("%s.%s.svc.cluster.local", limitador.ServiceName(limitadorObj), testNamespace),
 				Ports: limitadorv1alpha1.Ports{
 					GRPC: limitadorv1alpha1.DefaultServiceGRPCPort,
 					HTTP: limitadorv1alpha1.DefaultServiceHTTPPort,
 				},
 			}))
-		})
+		}, specTimeOut)
 
-		It("Should create a ConfigMap with empty limits", func() {
+		It("Should create a ConfigMap with empty limits", func(ctx SpecContext) {
 			createdConfigMap := corev1.ConfigMap{}
-			Eventually(func() bool {
-				err := k8sClient.Get(
-					context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(
+					ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.LimitsConfigMapName(limitadorObj),
 					},
-					&createdConfigMap)
-
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+					&createdConfigMap)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			var cmLimits []limitadorv1alpha1.RateLimit
 			err := yaml.Unmarshal([]byte(createdConfigMap.Data[limitador.LimitadorConfigFileName]), &cmLimits)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cmLimits).To(BeEmpty())
-		})
+		}, specTimeOut)
 
-		It("Should have not created PodDisruptionBudget", func() {
+		It("Should have not created PodDisruptionBudget", func(ctx SpecContext) {
 			pdb := &policyv1.PodDisruptionBudget{}
-			err := k8sClient.Get(context.TODO(),
+			err := k8sClient.Get(ctx,
 				types.NamespacedName{
 					Namespace: testNamespace,
 					Name:      limitador.PodDisruptionBudgetName(limitadorObj),
 				}, pdb)
 			// returns false when err is nil
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
-		})
+		}, specTimeOut)
 	})
 
 	Context("Creating a new Limitador object with rate limit headers", func() {
 		var limitadorObj *limitadorv1alpha1.Limitador
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			limitadorObj = basicLimitador(testNamespace)
-			limitadorObj.Spec.RateLimitHeaders = &[]limitadorv1alpha1.RateLimitHeadersType{"DRAFT_VERSION_03"}[0]
+			limitadorObj.Spec.RateLimitHeaders = ptr.To(limitadorv1alpha1.RateLimitHeadersType("DRAFT_VERSION_03"))
 
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
-		})
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
+		}, nodeTimeOut)
 
-		It("Should create a new deployment with rate limit headers command line arg", func() {
+		It("Should create a new deployment with rate limit headers command line arg", func(ctx SpecContext) {
 			createdLimitadorDeployment := appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(
-					context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(
+					ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
 					},
-					&createdLimitadorDeployment)
-
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+					&createdLimitadorDeployment)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			Expect(createdLimitadorDeployment.Spec.Template.Spec.Containers[0].Command).To(
 				HaveExactElements(
@@ -221,118 +209,100 @@ var _ = Describe("Limitador controller", func() {
 					"memory",
 				),
 			)
-		})
+		}, specTimeOut)
 	})
 
 	Context("Reconciling command line args for rate limit headers", func() {
 		var limitadorObj *limitadorv1alpha1.Limitador
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			limitadorObj = basicLimitador(testNamespace)
 
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
-		})
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
+		}, nodeTimeOut)
 
-		It("Should modify the limitador deployment command line args", func() {
+		It("Should modify the limitador deployment command line args", func(ctx SpecContext) {
 			updatedLimitador := limitadorv1alpha1.Limitador{}
-			Eventually(func() bool {
-				err := k8sClient.Get(
-					context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(
+					ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitadorObj.Name,
 					},
-					&updatedLimitador)
+					&updatedLimitador)).To(Succeed())
 
-				if err != nil {
-					return false
-				}
+				g.Expect(updatedLimitador.Spec.RateLimitHeaders).To(BeNil())
 
-				Expect(updatedLimitador.Spec.RateLimitHeaders).To(BeNil())
+				updatedLimitador.Spec.RateLimitHeaders = ptr.To(limitadorv1alpha1.RateLimitHeadersType("DRAFT_VERSION_03"))
+				g.Expect(k8sClient.Update(ctx, &updatedLimitador)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
-				updatedLimitador.Spec.RateLimitHeaders = &[]limitadorv1alpha1.RateLimitHeadersType{"DRAFT_VERSION_03"}[0]
-				return k8sClient.Update(context.TODO(), &updatedLimitador) == nil
-			}, timeout, interval).Should(BeTrue())
-
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				updatedLimitadorDeployment := appsv1.Deployment{}
-				err := k8sClient.Get(
-					context.TODO(),
+				g.Expect(k8sClient.Get(
+					ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
 					},
-					&updatedLimitadorDeployment)
-
-				if err != nil {
-					return false
-				}
-
-				return reflect.DeepEqual(updatedLimitadorDeployment.Spec.Template.Spec.Containers[0].Command,
-					[]string{
-						"limitador-server",
-						"--rate-limit-headers",
-						"DRAFT_VERSION_03",
-						"--http-port",
-						strconv.Itoa(int(limitadorv1alpha1.DefaultServiceHTTPPort)),
-						"--rls-port",
-						strconv.Itoa(int(limitadorv1alpha1.DefaultServiceGRPCPort)),
-						"/home/limitador/etc/limitador-config.yaml",
-						"memory",
-					})
-			}, timeout, interval).Should(BeTrue())
-		})
+					&updatedLimitadorDeployment)).To(Succeed())
+				g.Expect(updatedLimitadorDeployment.Spec.Template.Spec.Containers[0].Command).To(Equal([]string{
+					"limitador-server",
+					"--rate-limit-headers",
+					"DRAFT_VERSION_03",
+					"--http-port",
+					strconv.Itoa(int(limitadorv1alpha1.DefaultServiceHTTPPort)),
+					"--rls-port",
+					strconv.Itoa(int(limitadorv1alpha1.DefaultServiceGRPCPort)),
+					"/home/limitador/etc/limitador-config.yaml",
+					"memory",
+				}))
+			}).WithContext(ctx).Should(Succeed())
+		}, specTimeOut)
 	})
 
 	Context("Reconciling command line args for telemetry", func() {
 		var limitadorObj *limitadorv1alpha1.Limitador
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			limitadorObj = basicLimitador(testNamespace)
 
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
-		})
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
+		}, nodeTimeOut)
 
-		It("Should modify the limitador deployment command line args", func() {
-			updatedLimitador := limitadorv1alpha1.Limitador{}
-			Eventually(func() bool {
-				err := k8sClient.Get(
-					context.TODO(),
+		It("Should modify the limitador deployment command line args", func(ctx SpecContext) {
+			Eventually(func(g Gomega) {
+				updatedLimitador := limitadorv1alpha1.Limitador{}
+				g.Expect(k8sClient.Get(
+					ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitadorObj.Name,
 					},
-					&updatedLimitador)
+					&updatedLimitador)).To(Succeed())
 
-				if err != nil {
-					return false
-				}
-
-				Expect(updatedLimitador.Spec.Telemetry).To(BeNil())
+				g.Expect(updatedLimitador.Spec.Telemetry).To(BeNil())
 
 				telemetry := limitadorv1alpha1.Telemetry("exhaustive")
 				updatedLimitador.Spec.Telemetry = &telemetry
-				return k8sClient.Update(context.TODO(), &updatedLimitador) == nil
-			}, timeout, interval).Should(BeTrue())
+				g.Expect(k8sClient.Update(ctx, &updatedLimitador)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				updatedLimitadorDeployment := appsv1.Deployment{}
-				err := k8sClient.Get(
-					context.TODO(),
+				g.Expect(k8sClient.Get(
+					ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
 					},
-					&updatedLimitadorDeployment)
+					&updatedLimitadorDeployment)).Should(Succeed())
 
-				if err != nil {
-					return false
-				}
-
-				return reflect.DeepEqual(updatedLimitadorDeployment.Spec.Template.Spec.Containers[0].Command,
-					[]string{
+				g.Expect(updatedLimitadorDeployment.Spec.Template.Spec.Containers[0].Command).To(
+					Equal([]string{
 						"limitador-server",
 						"--limit-name-in-labels",
 						"--http-port",
@@ -341,32 +311,31 @@ var _ = Describe("Limitador controller", func() {
 						strconv.Itoa(int(limitadorv1alpha1.DefaultServiceGRPCPort)),
 						"/home/limitador/etc/limitador-config.yaml",
 						"memory",
-					})
-			}, timeout, interval).Should(BeTrue())
-		})
+					}))
+			}).WithContext(ctx).Should(Succeed())
+		}, specTimeOut)
 	})
 
 	Context("Creating a new Limitador object with verbosity", func() {
 		var limitadorObj *limitadorv1alpha1.Limitador
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			limitadorObj = basicLimitador(testNamespace)
-			limitadorObj.Spec.Verbosity = &[]limitadorv1alpha1.VerbosityLevel{3}[0]
+			limitadorObj.Spec.Verbosity = ptr.To(limitadorv1alpha1.VerbosityLevel(3))
 
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
-		})
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
+		}, nodeTimeOut)
 
-		It("Should create a new deployment with verbosity level command line arg", func() {
+		It("Should create a new deployment with verbosity level command line arg", func(ctx SpecContext) {
 			deployment := &appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
-					}, deployment)
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+					}, deployment)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(
 				HaveExactElements(
@@ -380,40 +349,39 @@ var _ = Describe("Limitador controller", func() {
 					"memory",
 				),
 			)
-		})
+		}, specTimeOut)
 	})
 
 	Context("Creating a new Limitador object with too high verbosity level", func() {
 		var limitadorObj *limitadorv1alpha1.Limitador
 
-		It("Should be rejected by k8s", func() {
+		It("Should be rejected by k8s", func(ctx SpecContext) {
 			limitadorObj = basicLimitador(testNamespace)
-			limitadorObj.Spec.Verbosity = &[]limitadorv1alpha1.VerbosityLevel{6}[0]
+			limitadorObj.Spec.Verbosity = ptr.To(limitadorv1alpha1.VerbosityLevel(6))
 
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).NotTo(Succeed())
-		})
+			Expect(k8sClient.Create(ctx, limitadorObj)).NotTo(Succeed())
+		}, specTimeOut)
 	})
 
 	Context("Reconciling command line args for verbosity", func() {
 		var limitadorObj *limitadorv1alpha1.Limitador
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			limitadorObj = basicLimitador(testNamespace)
 
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
-		})
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
+		}, nodeTimeOut)
 
-		It("Should modify the limitador deployment command line args", func() {
+		It("Should modify the limitador deployment command line args", func(ctx SpecContext) {
 			deployment := &appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
-					}, deployment)
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+					}, deployment)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			// verbosity level command line arg should be missing
 			Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(
@@ -430,90 +398,78 @@ var _ = Describe("Limitador controller", func() {
 
 			// Let's add verbosity level
 			updatedLimitador := limitadorv1alpha1.Limitador{}
-			Eventually(func() bool {
-				err := k8sClient.Get(context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitadorObj.Name,
-					}, &updatedLimitador)
+					}, &updatedLimitador)).To(Succeed())
 
-				if err != nil {
-					return false
-				}
+				updatedLimitador.Spec.Verbosity = ptr.To(limitadorv1alpha1.VerbosityLevel(3))
+				g.Expect(k8sClient.Update(ctx, &updatedLimitador)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
-				updatedLimitador.Spec.Verbosity = &[]limitadorv1alpha1.VerbosityLevel{3}[0]
-				return k8sClient.Update(context.TODO(), &updatedLimitador) == nil
-			}, timeout, interval).Should(BeTrue())
-
-			Eventually(func() bool {
+			Eventually(func(g Gomega) {
 				newDeployment := &appsv1.Deployment{}
-				err := k8sClient.Get(context.TODO(),
+				g.Expect(k8sClient.Get(ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
-					}, newDeployment)
+					}, newDeployment)).To(Succeed())
 
-				if err != nil {
-					return false
-				}
-
-				return reflect.DeepEqual(newDeployment.Spec.Template.Spec.Containers[0].Command,
-					[]string{
-						"limitador-server",
-						"-vvv",
-						"--http-port",
-						strconv.Itoa(int(limitadorv1alpha1.DefaultServiceHTTPPort)),
-						"--rls-port",
-						strconv.Itoa(int(limitadorv1alpha1.DefaultServiceGRPCPort)),
-						"/home/limitador/etc/limitador-config.yaml",
-						"memory",
-					})
-			}, timeout, interval).Should(BeTrue())
-		})
+				g.Expect(newDeployment.Spec.Template.Spec.Containers[0].Command).To(Equal([]string{
+					"limitador-server",
+					"-vvv",
+					"--http-port",
+					strconv.Itoa(int(limitadorv1alpha1.DefaultServiceHTTPPort)),
+					"--rls-port",
+					strconv.Itoa(int(limitadorv1alpha1.DefaultServiceGRPCPort)),
+					"/home/limitador/etc/limitador-config.yaml",
+					"memory",
+				}))
+			}).WithContext(ctx).Should(Succeed())
+		}, specTimeOut)
 	})
 
 	Context("Modifying limitador deployment objects", func() {
 		var limitadorObj *limitadorv1alpha1.Limitador
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			limitadorObj = basicLimitador(testNamespace)
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
-		})
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
+		}, nodeTimeOut)
 
-		It("User tries adding side-cars to deployment CR", func() {
+		It("User tries adding side-cars to deployment CR", func(ctx SpecContext) {
 			deploymentObj := appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(
-					context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(
+					ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
 					},
-					&deploymentObj)
-
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+					&deploymentObj)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			Expect(deploymentObj.Spec.Template.Spec.Containers).To(HaveLen(1))
 			containerObj := corev1.Container{Name: "newcontainer", Image: "someImage"}
 
 			deploymentObj.Spec.Template.Spec.Containers = append(deploymentObj.Spec.Template.Spec.Containers, containerObj)
 
-			Expect(k8sClient.Update(context.TODO(), &deploymentObj)).Should(Succeed())
+			Expect(k8sClient.Update(ctx, &deploymentObj)).Should(Succeed())
 			updateDeploymentObj := appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(
-					context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(
+					ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
 					},
-					&updateDeploymentObj)
-
-				return err == nil && len(updateDeploymentObj.Spec.Template.Spec.Containers) == 1
-			}, timeout, interval).Should(BeTrue())
-		})
+					&updateDeploymentObj)).To(Succeed())
+				g.Expect(updateDeploymentObj.Spec.Template.Spec.Containers).To(HaveLen(1))
+			}).WithContext(ctx).Should(Succeed())
+		}, specTimeOut)
 	})
 
 	// This test requires actual k8s cluster
@@ -521,19 +477,19 @@ var _ = Describe("Limitador controller", func() {
 	// used to validate custom resources using Common Expression Language (CEL)
 	// https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules
 	Context("Disk storage does not allow multiple replicas", func() {
-		It("resource is rejected", func() {
+		It("resource is rejected", func(ctx SpecContext) {
 			limitadorObj := limitadorWithInvalidDiskReplicas(testNamespace)
-			err := k8sClient.Create(context.TODO(), limitadorObj)
+			err := k8sClient.Create(ctx, limitadorObj)
 			Expect(err).To(HaveOccurred())
 			Expect(apierrors.IsInvalid(err)).To(BeTrue())
-		})
+		}, specTimeOut)
 	})
 
 	Context("Deploying limitador object with redis storage", func() {
 		var redisSecret *corev1.Secret
 
-		BeforeEach(func() {
-			deployRedis(testNamespace)
+		BeforeEach(func(ctx SpecContext) {
+			deployRedisWithContext(ctx, testNamespace)
 
 			redisSecret = &corev1.Secret{
 				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
@@ -544,43 +500,30 @@ var _ = Describe("Limitador controller", func() {
 				Type: corev1.SecretTypeOpaque,
 			}
 
-			err := k8sClient.Create(context.Background(), redisSecret)
+			err := k8sClient.Create(ctx, redisSecret)
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(func() bool {
-				secret := &corev1.Secret{}
-				err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(redisSecret), secret)
-				if err != nil {
-					if apierrors.IsNotFound(err) {
-						fmt.Fprintln(GinkgoWriter, "==== redis secret not found")
-					} else {
-						fmt.Fprintln(GinkgoWriter, "==== cannot read redis secret", "error", err)
-					}
+			secret := &corev1.Secret{}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(redisSecret), secret)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+		}, nodeTimeOut)
 
-					return false
-				}
-
-				return true
-			}, timeout, interval).Should(BeTrue())
-		})
-
-		It("command line is correct", func() {
+		It("command line is correct", func(ctx SpecContext) {
 			limitadorObj := limitadorWithRedisStorage(client.ObjectKeyFromObject(redisSecret), testNamespace)
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
 
 			deploymentObj := appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(
-					context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(
+					ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
 					},
-					&deploymentObj)
-
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+					&deploymentObj)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			Expect(deploymentObj.Spec.Template.Spec.Containers).To(HaveLen(1))
 			Expect(deploymentObj.Spec.Template.Spec.Containers[0].Command).To(
@@ -595,14 +538,14 @@ var _ = Describe("Limitador controller", func() {
 					"$(LIMITADOR_OPERATOR_REDIS_URL)",
 				),
 			)
-		})
+		}, specTimeOut)
 	})
 
 	Context("Deploying limitador object with redis cached storage", func() {
 		var redisSecret *corev1.Secret
 
-		BeforeEach(func() {
-			deployRedis(testNamespace)
+		BeforeEach(func(ctx SpecContext) {
+			deployRedisWithContext(ctx, testNamespace)
 
 			redisSecret = &corev1.Secret{
 				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
@@ -613,44 +556,31 @@ var _ = Describe("Limitador controller", func() {
 				Type: corev1.SecretTypeOpaque,
 			}
 
-			err := k8sClient.Create(context.Background(), redisSecret)
+			err := k8sClient.Create(ctx, redisSecret)
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(func() bool {
-				secret := &corev1.Secret{}
-				err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(redisSecret), secret)
-				if err != nil {
-					if apierrors.IsNotFound(err) {
-						fmt.Fprintln(GinkgoWriter, "redis secret not found")
-					} else {
-						fmt.Fprintln(GinkgoWriter, "cannot read redis secret", "error", err)
-					}
+			secret := &corev1.Secret{}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(redisSecret), secret)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+		}, nodeTimeOut)
 
-					return false
-				}
-
-				return true
-			}, timeout, interval).Should(BeTrue())
-		})
-
-		It("with all defaults, the command line is correct", func() {
+		It("with all defaults, the command line is correct", func(ctx SpecContext) {
 			limitadorObj := limitadorWithRedisCachedStorage(client.ObjectKeyFromObject(redisSecret), testNamespace)
 			limitadorObj.Spec.Storage.RedisCached.Options = nil
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(BeTrue())
 
 			deploymentObj := appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(
-					context.TODO(),
+			Eventually(func(g Gomega) {
+				Expect(k8sClient.Get(
+					ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
 					},
-					&deploymentObj)
-
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+					&deploymentObj)).To(Succeed())
+			}).WithContext(ctx).Should(BeTrue())
 
 			Expect(deploymentObj.Spec.Template.Spec.Containers).To(HaveLen(1))
 			Expect(deploymentObj.Spec.Template.Spec.Containers[0].Command).To(
@@ -665,9 +595,9 @@ var _ = Describe("Limitador controller", func() {
 					"$(LIMITADOR_OPERATOR_REDIS_URL)",
 				),
 			)
-		})
+		}, specTimeOut)
 
-		It("with all the optional parameters, the command line is correct", func() {
+		It("with all the optional parameters, the command line is correct", func(ctx SpecContext) {
 			limitadorObj := limitadorWithRedisCachedStorage(client.ObjectKeyFromObject(redisSecret), testNamespace)
 			limitadorObj.Spec.Storage.RedisCached.Options = &limitadorv1alpha1.RedisCachedOptions{
 				TTL:             ptr.To(1),
@@ -677,21 +607,19 @@ var _ = Describe("Limitador controller", func() {
 				ResponseTimeout: ptr.To(5),
 			}
 
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
 
 			deploymentObj := appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(
-					context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(
+					ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
 					},
-					&deploymentObj)
-
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+					&deploymentObj)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			Expect(deploymentObj.Spec.Template.Spec.Containers).To(HaveLen(1))
 			Expect(deploymentObj.Spec.Template.Spec.Containers[0].Command).To(
@@ -711,27 +639,25 @@ var _ = Describe("Limitador controller", func() {
 					"--response-timeout", "5",
 				),
 			)
-		})
+		}, specTimeOut)
 	})
 
 	Context("Deploying limitador object with disk storage", func() {
-		It("deployment is correct", func() {
+		It("deployment is correct", func(ctx SpecContext) {
 			limitadorObj := limitadorWithDiskStorage(testNamespace)
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
 
 			deploymentObj := appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(
-					context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(
+					ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
 					},
-					&deploymentObj)
-
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+					&deploymentObj)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			Expect(deploymentObj.Spec.Template.Spec.Volumes).To(HaveLen(2))
 			Expect(deploymentObj.Spec.Template.Spec.Volumes[1]).To(
@@ -770,118 +696,93 @@ var _ = Describe("Limitador controller", func() {
 					},
 				),
 			)
-		})
+		}, specTimeOut)
 
-		It("pvc is correct", func() {
+		It("pvc is correct", func(ctx SpecContext) {
 			limitadorObj := limitadorWithDiskStorage(testNamespace)
-			Expect(k8sClient.Create(context.TODO(), limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(limitadorObj), time.Minute, 5*time.Second).Should(BeTrue())
+			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
 
 			pvc := &corev1.PersistentVolumeClaim{}
-			Eventually(func() bool {
-				err := k8sClient.Get(
-					context.TODO(),
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(
+					ctx,
 					types.NamespacedName{
 						Name:      limitador.PVCName(limitadorObj),
 						Namespace: testNamespace,
 					},
-					pvc)
-
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+					pvc)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			Expect(pvc.GetOwnerReferences()).To(HaveLen(1))
-		})
+		}, specTimeOut)
 	})
 })
 
 func basicLimitador(ns string) *limitadorv1alpha1.Limitador {
-	// The name can't start with a number.
-	name := "a" + string(uuid.NewUUID())
-
 	return &limitadorv1alpha1.Limitador{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Limitador",
 			APIVersion: "limitador.kuadrant.io/v1alpha1",
 		},
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "limitador-", Namespace: ns},
 		Spec:       limitadorv1alpha1.LimitadorSpec{},
 	}
 }
 
 func limitadorWithRedisStorage(redisKey client.ObjectKey, ns string) *limitadorv1alpha1.Limitador {
-	return &limitadorv1alpha1.Limitador{
-		TypeMeta:   metav1.TypeMeta{Kind: "Limitador", APIVersion: "limitador.kuadrant.io/v1alpha1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "limitador-with-redis-storage", Namespace: ns},
-		Spec: limitadorv1alpha1.LimitadorSpec{
-			Storage: &limitadorv1alpha1.Storage{
-				Redis: &limitadorv1alpha1.Redis{
-					ConfigSecretRef: &corev1.LocalObjectReference{
-						Name: redisKey.Name,
-					},
-				},
+	l := basicLimitador(ns)
+	l.Spec.Storage = &limitadorv1alpha1.Storage{
+		Redis: &limitadorv1alpha1.Redis{
+			ConfigSecretRef: &corev1.LocalObjectReference{
+				Name: redisKey.Name,
 			},
 		},
 	}
+	return l
 }
 
 func limitadorWithRedisCachedStorage(key client.ObjectKey, ns string) *limitadorv1alpha1.Limitador {
-	return &limitadorv1alpha1.Limitador{
-		TypeMeta:   metav1.TypeMeta{Kind: "Limitador", APIVersion: "limitador.kuadrant.io/v1alpha1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "limitador-with-redis-cached-storage", Namespace: ns},
-		Spec: limitadorv1alpha1.LimitadorSpec{
-			Storage: &limitadorv1alpha1.Storage{
-				RedisCached: &limitadorv1alpha1.RedisCached{
-					ConfigSecretRef: &corev1.LocalObjectReference{
-						Name: key.Name,
-					},
-				},
+	l := basicLimitador(ns)
+	l.Spec.Storage = &limitadorv1alpha1.Storage{
+		RedisCached: &limitadorv1alpha1.RedisCached{
+			ConfigSecretRef: &corev1.LocalObjectReference{
+				Name: key.Name,
 			},
 		},
 	}
+	return l
 }
 
 func limitadorWithDiskStorage(ns string) *limitadorv1alpha1.Limitador {
-	return &limitadorv1alpha1.Limitador{
-		TypeMeta:   metav1.TypeMeta{Kind: "Limitador", APIVersion: "limitador.kuadrant.io/v1alpha1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "limitador-with-disk-storage", Namespace: ns},
-		Spec: limitadorv1alpha1.LimitadorSpec{
-			Storage: &limitadorv1alpha1.Storage{
-				Disk: &limitadorv1alpha1.DiskSpec{},
-			},
-		},
+	l := basicLimitador(ns)
+	l.Spec.Storage = &limitadorv1alpha1.Storage{
+		Disk: &limitadorv1alpha1.DiskSpec{},
 	}
+	return l
 }
 
 func limitadorWithInvalidDiskReplicas(ns string) *limitadorv1alpha1.Limitador {
-	return &limitadorv1alpha1.Limitador{
-		TypeMeta:   metav1.TypeMeta{Kind: "Limitador", APIVersion: "limitador.kuadrant.io/v1alpha1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "limitador-with-invalid-disk-replicas", Namespace: ns},
-		Spec: limitadorv1alpha1.LimitadorSpec{
-			Replicas: &[]int{2}[0],
-			Storage: &limitadorv1alpha1.Storage{
-				Disk: &limitadorv1alpha1.DiskSpec{},
-			},
-		},
+	l := basicLimitador(ns)
+	l.Spec.Replicas = ptr.To(2)
+	l.Spec.Storage = &limitadorv1alpha1.Storage{
+		Disk: &limitadorv1alpha1.DiskSpec{},
 	}
+	return l
 }
 
-func deployRedis(ns string) {
+func deployRedisWithContext(ctx context.Context, ns string) {
 	deployment := redisDeployment(ns)
-	Expect(k8sClient.Create(context.TODO(), deployment)).Should(Succeed())
-	Eventually(func() bool {
-		d := &appsv1.Deployment{}
-		err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(deployment), d)
-		return err == nil
-	}, timeout, interval).Should(BeTrue())
+	Expect(k8sClient.Create(ctx, deployment)).Should(Succeed())
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), &appsv1.Deployment{})).To(Succeed())
+	}).WithContext(ctx).Should(Succeed())
 
 	service := redisService(ns)
-	Expect(k8sClient.Create(context.TODO(), service)).Should(Succeed())
-	Eventually(func() bool {
-		s := &corev1.Service{}
-		err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(service), s)
-		return err == nil
-	}, timeout, interval).Should(BeTrue())
+	Expect(k8sClient.Create(ctx, service)).Should(Succeed())
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(service), &corev1.Service{})).To(Succeed())
+	}).WithContext(ctx).Should(Succeed())
 }
 
 func redisDeployment(ns string) *appsv1.Deployment {
@@ -922,39 +823,19 @@ func redisService(ns string) *corev1.Service {
 					Name:       "redis",
 					Protocol:   corev1.ProtocolTCP,
 					Port:       6379,
-					TargetPort: intstr.FromInt(6379),
+					TargetPort: intstr.FromInt32(6379),
 				},
 			},
 		},
 	}
 }
 
-func testLimitadorIsReady(l *limitadorv1alpha1.Limitador) func() bool {
-	return func() bool {
+func testLimitadorIsReady(ctx context.Context, l *limitadorv1alpha1.Limitador) func(g Gomega) {
+	return func(g Gomega) {
 		existing := &limitadorv1alpha1.Limitador{}
-		err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(l), existing)
-		return err == nil && meta.IsStatusConditionTrue(existing.Status.Conditions, "Ready")
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(l), existing)).To(Succeed())
+		g.Expect(meta.IsStatusConditionTrue(existing.Status.Conditions, limitadorv1alpha1.StatusConditionReady)).To(BeTrue())
 	}
-}
-
-func CreateNamespace(namespace *string) {
-	var generatedTestNamespace = "test-namespace-" + string(uuid.NewUUID())
-
-	nsObject := &corev1.Namespace{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"},
-		ObjectMeta: metav1.ObjectMeta{Name: generatedTestNamespace},
-	}
-
-	err := k8sClient.Create(context.Background(), nsObject)
-	Expect(err).ToNot(HaveOccurred())
-
-	existingNamespace := &corev1.Namespace{}
-	Eventually(func() bool {
-		err := k8sClient.Get(context.Background(), types.NamespacedName{Name: generatedTestNamespace}, existingNamespace)
-		return err == nil
-	}, time.Minute, 5*time.Second).Should(BeTrue())
-
-	*namespace = existingNamespace.Name
 }
 
 func CreateNamespaceWithContext(ctx context.Context, namespace *string) {
@@ -969,26 +850,9 @@ func CreateNamespaceWithContext(ctx context.Context, namespace *string) {
 
 func DeleteNamespaceWithContext(ctx context.Context, namespace *string) {
 	desiredTestNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: *namespace}}
-	Eventually(func() bool {
+	Eventually(func(g Gomega) {
 		err := k8sClient.Delete(ctx, desiredTestNamespace, client.PropagationPolicy(metav1.DeletePropagationForeground))
-		return err != nil && apierrors.IsNotFound(err)
-	}).WithContext(ctx).Should(BeTrue())
-}
-
-func DeleteNamespaceCallback(namespace *string) func() {
-	return func() {
-		desiredTestNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: *namespace}}
-		err := k8sClient.Delete(context.Background(), desiredTestNamespace, client.PropagationPolicy(metav1.DeletePropagationForeground))
-
-		Expect(err).ToNot(HaveOccurred())
-
-		existingNamespace := &corev1.Namespace{}
-		Eventually(func() bool {
-			err := k8sClient.Get(context.Background(), types.NamespacedName{Name: *namespace}, existingNamespace)
-			if err != nil && apierrors.IsNotFound(err) {
-				return true
-			}
-			return false
-		}, 3*time.Minute, 2*time.Second).Should(BeTrue())
-	}
+		g.Expect(err).ToNot(BeNil())
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	}).WithContext(ctx).Should(Succeed())
 }

--- a/controllers/limitador_controller_test.go
+++ b/controllers/limitador_controller_test.go
@@ -569,18 +569,18 @@ var _ = Describe("Limitador controller", func() {
 			limitadorObj := limitadorWithRedisCachedStorage(client.ObjectKeyFromObject(redisSecret), testNamespace)
 			limitadorObj.Spec.Storage.RedisCached.Options = nil
 			Expect(k8sClient.Create(ctx, limitadorObj)).Should(Succeed())
-			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(BeTrue())
+			Eventually(testLimitadorIsReady(ctx, limitadorObj)).WithContext(ctx).Should(Succeed())
 
 			deploymentObj := appsv1.Deployment{}
 			Eventually(func(g Gomega) {
-				Expect(k8sClient.Get(
+				g.Expect(k8sClient.Get(
 					ctx,
 					types.NamespacedName{
 						Namespace: testNamespace,
 						Name:      limitador.DeploymentName(limitadorObj),
 					},
 					&deploymentObj)).To(Succeed())
-			}).WithContext(ctx).Should(BeTrue())
+			}).WithContext(ctx).Should(Succeed())
 
 			Expect(deploymentObj.Spec.Template.Spec.Containers).To(HaveLen(1))
 			Expect(deploymentObj.Spec.Template.Spec.Containers[0].Command).To(

--- a/doc/development.md
+++ b/doc/development.md
@@ -2,7 +2,7 @@
 
 ## Technology stack required for development
 
-* [operator-sdk] version v1.28.1
+* [operator-sdk] version 1.32.0
 * [kind] version v0.22.0
 * [git][git_tool]
 * [go] version 1.21+

--- a/doc/development.md
+++ b/doc/development.md
@@ -3,7 +3,7 @@
 ## Technology stack required for development
 
 * [operator-sdk] version v1.28.1
-* [kind] version v0.20.0
+* [kind] version v0.22.0
 * [git][git_tool]
 * [go] version 1.21+
 * [kubernetes] version v1.25+

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/go-logr/logr v1.2.4
 	github.com/google/go-cmp v0.5.9
+	github.com/mitchellh/hashstructure v1.1.0
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	go.uber.org/zap v1.25.0
@@ -44,6 +45,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.21
 require (
 	github.com/go-logr/logr v1.2.4
 	github.com/google/go-cmp v0.5.9
-	github.com/mitchellh/hashstructure v1.1.0
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	go.uber.org/zap v1.25.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	go.uber.org/zap v1.25.0
-	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.28.3
 	k8s.io/apimachinery v0.28.3
@@ -56,6 +55,7 @@ require (
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,6 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/mitchellh/hashstructure v1.1.0 h1:P6P1hdjqAAknpY/M1CGipelZgp+4y9ja9kmUZPXP+H0=
-github.com/mitchellh/hashstructure v1.1.0/go.mod h1:xUDAozZz0Wmdiufv0uyhnHkUTN6/6d8ulp4AwfLKrmA=
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -54,6 +56,7 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJY
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
@@ -76,6 +79,10 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mitchellh/hashstructure v1.1.0 h1:P6P1hdjqAAknpY/M1CGipelZgp+4y9ja9kmUZPXP+H0=
+github.com/mitchellh/hashstructure v1.1.0/go.mod h1:xUDAozZz0Wmdiufv0uyhnHkUTN6/6d8ulp4AwfLKrmA=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
+github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/pkg/limitador/deployment_options_test.go
+++ b/pkg/limitador/deployment_options_test.go
@@ -8,6 +8,7 @@ import (
 	is "gotest.tools/assert/cmp"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 )
@@ -38,7 +39,7 @@ func TestDeploymentCommand(t *testing.T) {
 
 	t.Run("when rate limit headers set in the spec command line args includes --rate-limit-headers", func(subT *testing.T) {
 		limObj := basicLimitador()
-		limObj.Spec.RateLimitHeaders = &[]limitadorv1alpha1.RateLimitHeadersType{"DRAFT_VERSION_03"}[0]
+		limObj.Spec.RateLimitHeaders = ptr.To(limitadorv1alpha1.RateLimitHeadersType("DRAFT_VERSION_03"))
 
 		command := DeploymentCommand(limObj, DeploymentStorageOptions{Command: []string{"memory"}})
 		assert.DeepEqual(subT, command,
@@ -100,7 +101,7 @@ func TestDeploymentCommand(t *testing.T) {
 		for _, tt := range tests {
 			subT.Run(tt.Name, func(subTest *testing.T) {
 				limObj := basicLimitador()
-				limObj.Spec.Verbosity = &[]limitadorv1alpha1.VerbosityLevel{tt.VerbosityLevel}[0]
+				limObj.Spec.Verbosity = ptr.To(tt.VerbosityLevel)
 				command := DeploymentCommand(limObj, DeploymentStorageOptions{})
 				assert.Assert(subTest, is.Contains(command, tt.ExpectedArg))
 			})

--- a/pkg/limitador/disk_storage_options_test.go
+++ b/pkg/limitador/disk_storage_options_test.go
@@ -7,6 +7,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 )
@@ -49,17 +50,17 @@ func TestDiskDeploymentOptions(t *testing.T) {
 		limObj := basicLimitador()
 		options, err := DiskDeploymentOptions(
 			limObj,
-			limitadorv1alpha1.DiskSpec{Optimize: &[]limitadorv1alpha1.DiskOptimizeType{limitadorv1alpha1.DiskOptimizeTypeDisk}[0]},
+			limitadorv1alpha1.DiskSpec{Optimize: ptr.To(limitadorv1alpha1.DiskOptimizeTypeDisk)},
 		)
 		assert.NilError(subT, err)
 		assert.DeepEqual(subT, options,
 			DeploymentStorageOptions{
 				Command: []string{"disk", "--optimize", string(limitadorv1alpha1.DiskOptimizeTypeDisk), DiskPath},
 				VolumeMounts: []v1.VolumeMount{
-					v1.VolumeMount{ReadOnly: false, Name: DiskVolumeName, MountPath: DiskPath},
+					{ReadOnly: false, Name: DiskVolumeName, MountPath: DiskPath},
 				},
 				Volumes: []v1.Volume{
-					v1.Volume{
+					{
 						Name: DiskVolumeName,
 						VolumeSource: v1.VolumeSource{
 							PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{

--- a/pkg/limitador/k8s_objects.go
+++ b/pkg/limitador/k8s_objects.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	DefaultReplicas     = 1
 	LimitadorRepository = "quay.io/kuadrant/limitador"
 	StatusEndpoint      = "/status"
 )
@@ -55,10 +54,7 @@ func Service(limitador *limitadorv1alpha1.Limitador) *v1.Service {
 }
 
 func Deployment(limitador *limitadorv1alpha1.Limitador, deploymentOptions DeploymentOptions) *appsv1.Deployment {
-	var replicas int32 = DefaultReplicas
-	if limitador.Spec.Replicas != nil {
-		replicas = int32(*limitador.Spec.Replicas)
-	}
+	replicas := limitador.GetReplicas()
 
 	image := GetLimitadorImageVersion()
 	if limitador.Spec.Version != nil {

--- a/pkg/limitador/k8s_objects_test.go
+++ b/pkg/limitador/k8s_objects_test.go
@@ -21,7 +21,6 @@ var intStrOne = &intstr.IntOrString{
 }
 
 func TestConstants(t *testing.T) {
-	assert.Check(t, DefaultReplicas == 1)
 	assert.Check(t, LimitadorRepository == "quay.io/kuadrant/limitador")
 	assert.Check(t, StatusEndpoint == "/status")
 	assert.Check(t, LimitadorConfigFileName == "limitador-config.yaml")

--- a/pkg/limitador/k8s_objects_test.go
+++ b/pkg/limitador/k8s_objects_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
@@ -75,7 +76,7 @@ func TestDeployment(t *testing.T) {
 
 	t.Run("replicas", func(subT *testing.T) {
 		limObj := newTestLimitadorObj("some-name", "some-ns", nil)
-		limObj.Spec.Replicas = &[]int{2}[0]
+		limObj.Spec.Replicas = ptr.To(2)
 		deployment := Deployment(limObj, DeploymentOptions{})
 		assert.Assert(subT, deployment.Spec.Replicas != nil)
 		assert.Assert(subT, *deployment.Spec.Replicas == 2)
@@ -381,9 +382,9 @@ func TestPVC(t *testing.T) {
 	t.Run("custom storage class", func(subT *testing.T) {
 		limObj := newDiskStorageLimitador("some-name")
 		limObj.Spec.Storage.Disk.PVC = &limitadorv1alpha1.PVCGenericSpec{
-			StorageClassName: &[]string{"myCustomStorage"}[0],
+			StorageClassName: ptr.To("myCustomStorage"),
 		}
 		pvc := PVC(limObj)
-		assert.DeepEqual(subT, pvc.Spec.StorageClassName, &[]string{"myCustomStorage"}[0])
+		assert.DeepEqual(subT, pvc.Spec.StorageClassName, ptr.To("myCustomStorage"))
 	})
 }

--- a/utils/kind-cluster.yaml
+++ b/utils/kind-cluster.yaml
@@ -3,4 +3,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.27.3
+  image: kindest/node:v1.29.2


### PR DESCRIPTION
# Description
Part of https://github.com/Kuadrant/kuadrant-operator/issues/414

This PR adds a feature to annotate Limitador pods with the limits config map resource version. This change ensures that modifications to the limits will promptly trigger a reload or synchronization of the limit configuration to Limitador pods. Consequently, it ensures that pod limits are always immediately up to date.

This enhancement will enable us to utilize the Limitador CR `Ready` condition as a way of naively assuming that limits are enforced.

Other additions include
* Updating kind to v0.22.0
* Refactor integration tests to use context to timeout tests and algin primarily use Gomega for assertions

# Verification
The following have already been verified in the included integration test but if you want to verify manually:
* Checkout this branch
* Create local cluster
```
 make local-setup
```
* Watch for limitador pod annotations
```
watch "kubectl get pods -o yaml | yq '.items[].metadata.annotations'"
```
* Deploy limitador CR
```
kubectl apply -f -<<EOF                                          
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador-sample
spec:
  replicas: 2
  limits:
    - conditions: ["get_toy == 'yes'"]
      max_value: 10
      namespace: toystore-app
      seconds: 30
      variables: []
EOF
```
* Verify annotation is added to the pods
* Watch limits in a limitador pod
```
watch "kubectl exec $(kubectl get pods -l app=limitador -o yaml | yq '.items[0].metadata.name') -c limitador -- cat /home/limitador/etc/limitador-config.yaml"
```
* Update limits
```
kubectl apply -f -<<EOF                                          
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador-sample
spec:
  replicas: 2
  limits:
    - conditions: ["get_toy == 'yes'"]
      max_value: 20
      namespace: toystore-app
      seconds: 60
      variables: []
EOF
```
* Verify annotation of config map resource version is updated
* Verify config map in pod is immediately updated / synced to new value once annotation is updated
