### PR TITLE
Add limitador tracing-endpoint command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ spec:
 * [Storage Options](./doc/storage.md)
 * [Rate Limit Headers](./doc/rate-limit-headers.md)
 * [Logging](./doc/logging.md)
+* [Tracing](./doc/tracing.md)
 
 ## Contributing
 

--- a/api/v1alpha1/limitador_types.go
+++ b/api/v1alpha1/limitador_types.go
@@ -87,6 +87,9 @@ type LimitadorSpec struct {
 	Telemetry *Telemetry `json:"telemetry,omitempty"`
 
 	// +optional
+	Tracing *Tracing `json:"tracing,omitempty"`
+
+	// +optional
 	Limits []RateLimit `json:"limits,omitempty"`
 
 	// +optional
@@ -322,6 +325,10 @@ type LimitadorService struct {
 type Ports struct {
 	HTTP int32 `json:"http,omitempty"`
 	GRPC int32 `json:"grpc,omitempty"`
+}
+
+type Tracing struct {
+	Endpoint string `json:"endpoint"`
 }
 
 type PodDisruptionBudgetType struct {

--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/limitador-operator:latest
-    createdAt: "2024-04-04T14:34:19Z"
+    createdAt: "2024-04-15T10:48:14Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/limitador-operator

--- a/bundle/manifests/limitador.kuadrant.io_limitadors.yaml
+++ b/bundle/manifests/limitador.kuadrant.io_limitadors.yaml
@@ -1083,6 +1083,13 @@ spec:
                 - basic
                 - exhaustive
                 type: string
+              tracing:
+                properties:
+                  endpoint:
+                    type: string
+                required:
+                - endpoint
+                type: object
               verbosity:
                 description: Sets the level of verbosity
                 maximum: 4

--- a/config/crd/bases/limitador.kuadrant.io_limitadors.yaml
+++ b/config/crd/bases/limitador.kuadrant.io_limitadors.yaml
@@ -1084,6 +1084,13 @@ spec:
                 - basic
                 - exhaustive
                 type: string
+              tracing:
+                properties:
+                  endpoint:
+                    type: string
+                required:
+                - endpoint
+                type: object
               verbosity:
                 description: Sets the level of verbosity
                 maximum: 4

--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -1,0 +1,30 @@
+# Tracing
+
+Limitador offers distributed tracing enablement using the `.spec.tracing` CR configuration:
+
+```yaml
+---
+apiVersion: limitador.kuadrant.io/v1alpha1
+kind: Limitador
+metadata:
+  name: limitador-sample
+spec:
+  listener:
+    http:
+      port: 8080
+    grpc:
+      port: 8081
+  limits:
+    - conditions: ["get_toy == 'yes'"]
+      max_value: 2
+      namespace: toystore-app
+      seconds: 30
+      variables: []
+  verbosity: 3
+  tracing:
+    endpoint: rpc://my-otlp-collector:4317
+```
+
+Currently limitador only supports collectors using the OpenTelemetry Protocol with TLS disabled. The `endpoint` configuration option should contain the scheme, host and port of the service. The quantity and level of the information provided by the spans is configured via the `verbosity` argument.
+
+![Limitador tracing example](https://github.com/Kuadrant/limitador-operator/assets/6575004/7bdc7c17-37a5-4dfe-ac56-432efa1070c4)

--- a/pkg/limitador/deployment_options.go
+++ b/pkg/limitador/deployment_options.go
@@ -45,6 +45,10 @@ func DeploymentCommand(limObj *limitadorv1alpha1.Limitador, storageOptions Deplo
 		command = append(command, "--limit-name-in-labels")
 	}
 
+	if limObj.Spec.Tracing != nil {
+		command = append(command, "--tracing-endpoint", limObj.Spec.Tracing.Endpoint)
+	}
+
 	if limObj.Spec.Verbosity != nil {
 		command = append(command, fmt.Sprintf("-%s", strings.Repeat("v", int(*limObj.Spec.Verbosity))))
 	}

--- a/pkg/limitador/deployment_options_test.go
+++ b/pkg/limitador/deployment_options_test.go
@@ -107,6 +107,26 @@ func TestDeploymentCommand(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("command from tracing endpoint appended", func(subT *testing.T) {
+		testEndpoint := "rpc://tracing-endpoint:4317"
+		limObj := basicLimitador()
+		limObj.Spec.Tracing = &limitadorv1alpha1.Tracing{
+			Endpoint: testEndpoint,
+		}
+		command := DeploymentCommand(limObj, DeploymentStorageOptions{})
+		assert.DeepEqual(subT, command,
+			[]string{
+				"limitador-server",
+				"--tracing-endpoint",
+				testEndpoint,
+				"--http-port",
+				strconv.Itoa(int(limitadorv1alpha1.DefaultServiceHTTPPort)),
+				"--rls-port",
+				strconv.Itoa(int(limitadorv1alpha1.DefaultServiceGRPCPort)),
+				"/home/limitador/etc/limitador-config.yaml",
+			})
+	})
 }
 
 func TestDeploymentVolumeMounts(t *testing.T) {


### PR DESCRIPTION
##  Changes
A new `--tracing-endpoint` command was added to limitador in https://github.com/Kuadrant/limitador/pull/261. I have used a struct to match the spec in Authorino (eventually to contain an `Insecure` boolean once limitador supports TLS tracing endpoint).

`docker run --rm -t quay.io/kuadrant/limitador:latest limitador-server --help`
```sh
Rate Limiting Server

Usage: limitador-server [OPTIONS] <LIMITS_FILE> [STORAGE]

STORAGES:
  memory        Counters are held in Limitador (ephemeral)
  disk          Counters are held on disk (persistent)
  redis         Uses Redis to store counters
  redis_cached  Uses Redis to store counters, with an in-memory cache

Arguments:
  <LIMITS_FILE>  The limit file to use

Options:
  -b, --rls-ip <ip>
          The IP to listen on for RLS [default: 0.0.0.0]
  -p, --rls-port <port>
          The port to listen on for RLS [default: 8081]
  -B, --http-ip <http_ip>
          The IP to listen on for HTTP [default: 0.0.0.0]
  -P, --http-port <http_port>
          The port to listen on for HTTP [default: 8080]
  -l, --limit-name-in-labels
          Include the Limit Name in prometheus label
      --tracing-endpoint <tracing_endpoint>
          The host for the tracing service [default: ]
  -v...
          Sets the level of verbosity
      --validate
          Validates the LIMITS_FILE and exits
  -H, --rate-limit-headers <rate_limit_headers>
          Enables rate limit response headers [default: NONE] [possible values: NONE, DRAFT_VERSION_03]
      --grpc-reflection-service
          Enables gRPC server reflection service
  -h, --help
          Print help
  -V, --version
          Print version
```

## Verification Steps

Deploy cluster:
```sh
make local-setup
```

Create limitador CR with `.spec.tracing.endpoint` set:
```sh
kubectl apply -f - <<EOF
---
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador
spec:
  listener:
    http:
      port: 8080
    grpc:
      port: 8081
  tracing:
    endpoint: rpc://tracing-endpoint:4317
  limits:
    - conditions: ["get_toy == 'yes'"]
      max_value: 2
      namespace: toystore-app
      seconds: 30
      variables: []
EOF
```

Wait for deployment:
```sh
kubectl wait --timeout=300s --for=condition=Ready limitador limitador
```

Check limitador deployment command:
```sh
kubectl get deployment/limitador-limitador  -o yaml | yq '.spec.template.spec.containers[0].command'
```

```sh
- limitador-server
- --tracing-endpoint
- rpc://tracing-endpoint:4317
- --http-port
- "8080"
- --rls-port
- "8081"
- /home/limitador/etc/limitador-config.yaml
- memory
```