### PR TITLE
Hello helm

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -1,0 +1,68 @@
+name: release-helm-chart
+on:
+# TODO: The following commented lines should be used depending on the release strategy
+#  release:
+#    types:
+#      - released
+# OR for a full release workflow
+#  push:
+#    tags:
+#        - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      operatorVersion:
+          description: Operator bundle version
+          default: 0.0.0
+          type: string
+      limitadorVersion:
+        description: Limitador version
+        default: latest
+        type: string
+      releaseId:
+        description: Release ID
+        default: 0
+        type: string
+
+jobs:
+  chart_release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref }}
+        fetch-depth: 0
+
+    - name: Configure Git
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+    - name: Build the Helm Chart manifests
+      run: |
+        make helm-build \
+          VERSION=${{ inputs.operatorVersion }} \
+          LIMITADOR_VERSION=${{ inputs.limitadorVersion }}
+
+    - name: Package Helm Chart
+      run: |
+        make helm-package
+
+    - name: Upload package to GitHub Release
+      run: |
+        response = make helm-upload-package \
+        VERSION=${{ inputs.operatorVersion }} \
+        GITHUB_TOKEN=${{ secrets.HELM_WORKFLOWS_TOKEN }} \
+        RELEASE_ID=${{ inputs.releaseId }}
+        echo "response: $response" >> $GITHUB_ENV
+
+    - name: Sync Helm Chart with repository
+      run: |
+        make helm-sync-package \
+          VERSION=${{ inputs.operatorVersion }} \
+          GITHUB_TOKEN=${{ secrets.HELM_WORKFLOWS_TOKEN }} \
+          ASSET_ID=${{ env.response.id }}
+          BROWSER_DOWNLOAD_URL=${{ env.response.browser_download_url }}

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -52,17 +52,18 @@ jobs:
         make helm-package
 
     - name: Upload package to GitHub Release
-      run: |
-        response = make helm-upload-package \
-        VERSION=${{ inputs.operatorVersion }} \
-        GITHUB_TOKEN=${{ secrets.HELM_WORKFLOWS_TOKEN }} \
-        RELEASE_ID=${{ inputs.releaseId }}
-        echo "response: $response" >> $GITHUB_ENV
+      uses: svenstaro/upload-release-action@v2
+      id: upload-chart
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: charts/limitador-operator-${{ inputs.operatorVersion }}.tgz
+        asset_name: chart-limitador-operator-${{ inputs.operatorVersion }}.tgz
+        tag: ${{ github.ref }}
+        overwrite: true
 
     - name: Sync Helm Chart with repository
       run: |
         make helm-sync-package \
           VERSION=${{ inputs.operatorVersion }} \
           GITHUB_TOKEN=${{ secrets.HELM_WORKFLOWS_TOKEN }} \
-          ASSET_ID=${{ env.response.id }}
-          BROWSER_DOWNLOAD_URL=${{ env.response.browser_download_url }}
+          BROWSER_DOWNLOAD_URL=${{ steps.upload-chart.outputs.browser_download_url }}

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -65,5 +65,5 @@ jobs:
       run: |
         make helm-sync-package \
           VERSION=${{ inputs.operatorVersion }} \
-          GITHUB_TOKEN=${{ secrets.HELM_WORKFLOWS_TOKEN }} \
+          HELM_WORKFLOWS_TOKEN=${{ secrets.HELM_WORKFLOWS_TOKEN }} \
           BROWSER_DOWNLOAD_URL=${{ steps.upload-chart.outputs.browser_download_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.so
 *.dylib
 bin
-limitador-operator
+/limitador-operator
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ REGISTRY = quay.io
 
 # Organization in container resgistry
 ORG ?= kuadrant
+REPO_NAME ?= limitador-operator
 
 # kubebuilder-tools still doesn't support darwin/arm64. This is a workaround (https://github.com/kubernetes-sigs/controller-runtime/issues/1657)
 ARCH_PARAM =

--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,23 @@ $(GINKGO):
 .PHONY: ginkgo
 ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.
 
+HELM = $(PROJECT_PATH)/bin/helm
+HELM_VERSION = v3.15.0
+$(HELM):
+	@{ \
+	set -e ;\
+	mkdir -p $(dir $(HELM)) ;\
+	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+	wget -O helm.tar.gz https://get.helm.sh/helm-$(HELM_VERSION)-$${OS}-$${ARCH}.tar.gz ;\
+	tar -zxvf helm.tar.gz ;\
+	mv $${OS}-$${ARCH}/helm $(HELM) ;\
+	chmod +x $(HELM) ;\
+	rm -rf $${OS}-$${ARCH} helm.tar.gz ;\
+	}
+
+.PHONY: helm
+helm: $(HELM) ## Download helm locally if necessary.
+
 ##@ General
 
 # The help target prints out all targets with their descriptions organized

--- a/charts/limitador-operator/.helmignore
+++ b/charts/limitador-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/limitador-operator/Chart.yaml
+++ b/charts/limitador-operator/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: limitador-operator
+description: A Helm chart for Limitador Operator
+type: application
+version: "0.1.0-dev"
+appVersion: "latest"
+maintainers:
+  - email: asnaps@redhat.com
+    name: Alex Snaps
+  - email: didier@redhat.com
+    name: Didier Di Cesare
+  - email: eastizle@redhat.com
+    name: Eguzki Astiz Lezaun

--- a/charts/limitador-operator/Chart.yaml
+++ b/charts/limitador-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: limitador-operator
 description: A Helm chart for Limitador Operator
 type: application
-version: "0.1.0-dev"
-appVersion: "latest"
+# The version will be properly set when the chart is released matching the operator version
+version: "0.0.0"
 maintainers:
   - email: asnaps@redhat.com
     name: Alex Snaps

--- a/charts/limitador-operator/templates/manifests.yaml
+++ b/charts/limitador-operator/templates/manifests.yaml
@@ -1,0 +1,1438 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: limitador-operator-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  name: limitadors.limitador.kuadrant.io
+spec:
+  group: limitador.kuadrant.io
+  names:
+    kind: Limitador
+    listKind: LimitadorList
+    plural: limitadors
+    singular: limitador
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Limitador is the Schema for the limitadors API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LimitadorSpec defines the desired state of Limitador
+            properties:
+              affinity:
+                description: Affinity is a group of affinity scheduling rules.
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              image:
+                type: string
+              limits:
+                items:
+                  description: RateLimit defines the desired Limitador limit
+                  properties:
+                    conditions:
+                      items:
+                        type: string
+                      type: array
+                    max_value:
+                      type: integer
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    seconds:
+                      type: integer
+                    variables:
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - conditions
+                  - max_value
+                  - namespace
+                  - seconds
+                  - variables
+                  type: object
+                type: array
+              listener:
+                properties:
+                  grpc:
+                    properties:
+                      port:
+                        format: int32
+                        type: integer
+                    type: object
+                  http:
+                    properties:
+                      port:
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+              pdb:
+                properties:
+                  maxUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: An eviction is allowed if at most "maxUnavailable"
+                      limitador pods are unavailable after the eviction, i.e. even
+                      in absence of the evicted pod. For example, one can prevent
+                      all voluntary evictions by specifying 0. This is a mutually
+                      exclusive setting with "minAvailable".
+                    x-kubernetes-int-or-string: true
+                  minAvailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: An eviction is allowed if at least "minAvailable"
+                      limitador pods will still be available after the eviction, i.e.
+                      even in the absence of the evicted pod.  So for example you
+                      can prevent all voluntary evictions by specifying "100%".
+                    x-kubernetes-int-or-string: true
+                type: object
+              rateLimitHeaders:
+                description: RateLimitHeadersType defines the valid options for the
+                  --rate-limit-headers arg
+                enum:
+                - NONE
+                - DRAFT_VERSION_03
+                type: string
+              replicas:
+                type: integer
+              resourceRequirements:
+                description: ResourceRequirements describes the compute resource requirements.
+                properties:
+                  claims:
+                    description: "Claims lists the names of resources, defined in
+                      spec.resourceClaims, that are used by this container. \n This
+                      is an alpha field and requires enabling the DynamicResourceAllocation
+                      feature gate. \n This field is immutable. It can only be set
+                      for containers."
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: Name must match the name of one entry in pod.spec.resourceClaims
+                            of the Pod where this field is used. It makes that resource
+                            available inside a container.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              storage:
+                description: Storage contains the options for Limitador counters database
+                  or in-memory data storage
+                properties:
+                  disk:
+                    properties:
+                      optimize:
+                        description: DiskOptimizeType defines the valid options for
+                          "optimize" option of the disk persistence type
+                        enum:
+                        - throughput
+                        - disk
+                        type: string
+                      persistentVolumeClaim:
+                        properties:
+                          resources:
+                            description: Resources represents the minimum resources
+                              the volume should have. Ignored when VolumeName field
+                              is set
+                            properties:
+                              requests:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'Storage Resource requests to be used
+                                  on the PersistentVolumeClaim. To learn more about
+                                  resource requests see: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - requests
+                            type: object
+                          storageClassName:
+                            type: string
+                          volumeName:
+                            description: VolumeName is the binding reference to the
+                              PersistentVolume backing this claim.
+                            type: string
+                        type: object
+                    type: object
+                  redis:
+                    properties:
+                      configSecretRef:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  redis-cached:
+                    properties:
+                      configSecretRef:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      options:
+                        properties:
+                          flush-period:
+                            description: 'FlushPeriod for counters in milliseconds
+                              [default: 1000]'
+                            type: integer
+                          max-cached:
+                            description: 'MaxCached refers to the maximum amount of
+                              counters cached [default: 10000]'
+                            type: integer
+                          response-timeout:
+                            description: 'ResponseTimeout defines the timeout for
+                              Redis commands in milliseconds [default: 350]'
+                            type: integer
+                        type: object
+                    type: object
+                type: object
+              telemetry:
+                description: Telemetry defines the level of metrics Limitador will
+                  expose to the user
+                enum:
+                - basic
+                - exhaustive
+                type: string
+              tracing:
+                properties:
+                  endpoint:
+                    type: string
+                required:
+                - endpoint
+                type: object
+              verbosity:
+                description: Sets the level of verbosity
+                maximum: 4
+                minimum: 1
+                type: integer
+              version:
+                description: '[Deprecated] Use spec.image instead. Docker tag used
+                  as limitador image. The repo is hardcoded to quay.io/kuadrant/limitador'
+                type: string
+            type: object
+            x-kubernetes-validations:
+            - message: disk storage does not allow multiple replicas
+              rule: (!has(self.storage) || !has(self.storage.disk)) || (!has(self.replicas)
+                || self.replicas < 2)
+          status:
+            description: LimitadorStatus defines the observed state of Limitador
+            properties:
+              conditions:
+                description: 'Represents the observations of a foo''s current state.
+                  Known .status.conditions.type are: "Ready"'
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
+              service:
+                description: Service provides information about the service exposing
+                  limitador API
+                properties:
+                  host:
+                    type: string
+                  ports:
+                    properties:
+                      grpc:
+                        format: int32
+                        type: integer
+                      http:
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: limitador-operator-controller-manager
+  namespace: limitador-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: limitador-operator-leader-election-role
+  namespace: limitador-operator-system
+rules:
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: limitador-operator-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - persistentvolumeclaims
+  - secrets
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - limitador.kuadrant.io
+  resources:
+  - limitadors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - limitador.kuadrant.io
+  resources:
+  - limitadors/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - limitador.kuadrant.io
+  resources:
+  - limitadors/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: limitador-operator-leader-election-rolebinding
+  namespace: limitador-operator-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: limitador-operator-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: limitador-operator-controller-manager
+  namespace: limitador-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: limitador-operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: limitador-operator-manager-role
+subjects:
+- kind: ServiceAccount
+  name: limitador-operator-controller-manager
+  namespace: limitador-operator-system
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: :8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: 3745a16e.kuadrant.io
+kind: ConfigMap
+metadata:
+  name: limitador-operator-manager-config
+  namespace: limitador-operator-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: limitador-operator-controller-manager-metrics-service
+  namespace: limitador-operator-system
+spec:
+  ports:
+  - name: metrics
+    port: 8080
+    targetPort: metrics
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: limitador-operator-controller-manager
+  namespace: limitador-operator-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        command:
+        - /manager
+        env:
+        - name: RELATED_IMAGE_LIMITADOR
+          value: quay.io/kuadrant/limitador:latest
+        image: quay.io/kuadrant/limitador-operator:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 8080
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 200m
+            memory: 300Mi
+          requests:
+            cpu: 200m
+            memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: limitador-operator-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/charts/limitador-operator/templates/manifests.yaml
+++ b/charts/limitador-operator/templates/manifests.yaml
@@ -1062,6 +1062,10 @@ spec:
                         x-kubernetes-map-type: atomic
                       options:
                         properties:
+                          batch-size:
+                            description: 'BatchSize defines the size of entries to
+                              flush in as single flush [default: 100]'
+                            type: integer
                           flush-period:
                             description: 'FlushPeriod for counters in milliseconds
                               [default: 1000]'

--- a/charts/limitador-operator/values.yaml
+++ b/charts/limitador-operator/values.yaml
@@ -1,0 +1,1 @@
+# For its first iteration, this chart won't be configurable with helm settings

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- ../default

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -1,0 +1,12 @@
+##@ Helm Charts
+
+.PHONY: helm-build
+helm-build: ## Builds the helm chart from kustomize manifests
+	# Generate kustomize manifests out of code notations
+	$(OPERATOR_SDK) generate kustomize manifests -q
+	# Set desired operator image and related limitador image
+	V="$(RELATED_IMAGE_LIMITADOR)" $(YQ) eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_LIMITADOR").value) = strenv(V)' -i config/manager/manager.yaml
+	# Replace the controller image
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
+	# Build the helm chart templates from kustomize manifests
+	$(KUSTOMIZE) build config/helm > charts/limitador-operator/templates/manifests.yaml

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -1,7 +1,7 @@
 ##@ Helm Charts
 
 .PHONY: helm-build
-helm-build: ## Builds the helm chart from kustomize manifests
+helm-build: ## Build the helm chart from kustomize manifests
 	# Generate kustomize manifests out of code notations
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	# Set desired operator image and related limitador image
@@ -10,3 +10,18 @@ helm-build: ## Builds the helm chart from kustomize manifests
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	# Build the helm chart templates from kustomize manifests
 	$(KUSTOMIZE) build config/helm > charts/limitador-operator/templates/manifests.yaml
+
+.PHONY: helm-install
+helm-install: $(HELM) ## Install the helm chart
+	# Install the helm chart in the cluster
+	$(HELM) install limitador-operator charts/limitador-operator
+
+.PHONY: helm-uninstall
+helm-uninstall: $(HELM) ## Uninstall the helm chart
+	# Uninstall the helm chart from the cluster
+	$(HELM) uninstall limitador-operator
+
+.PHONY: helm-upgrade
+helm-upgrade: $(HELM) ## Upgrade the helm chart
+	# Upgrade the helm chart in the cluster
+	$(HELM) upgrade limitador-operator charts/limitador-operator

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -8,6 +8,7 @@ helm-build: $(KUSTOMIZE) $(OPERATOR_SDK) $(YQ) manifests ## Build the helm chart
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	# Build the helm chart templates from kustomize manifests
 	$(KUSTOMIZE) build config/helm > charts/limitador-operator/templates/manifests.yaml
+	V="$(VERSION)" $(YQ) eval '.version = strenv(V)' -i charts/limitador-operator/Chart.yaml
 
 .PHONY: helm-install
 helm-install: $(HELM) ## Install the helm chart

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -1,9 +1,7 @@
 ##@ Helm Charts
 
 .PHONY: helm-build
-helm-build: ## Build the helm chart from kustomize manifests
-	# Generate kustomize manifests out of code notations
-	$(OPERATOR_SDK) generate kustomize manifests -q
+helm-build: $(KUSTOMIZE) $(OPERATOR_SDK) $(YQ) manifests ## Build the helm chart from kustomize manifests
 	# Set desired operator image and related limitador image
 	V="$(RELATED_IMAGE_LIMITADOR)" $(YQ) eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_LIMITADOR").value) = strenv(V)' -i config/manager/manager.yaml
 	# Replace the controller image
@@ -25,3 +23,43 @@ helm-uninstall: $(HELM) ## Uninstall the helm chart
 helm-upgrade: $(HELM) ## Upgrade the helm chart
 	# Upgrade the helm chart in the cluster
 	$(HELM) upgrade limitador-operator charts/limitador-operator
+
+.PHONY: helm-package
+helm-package: $(HELM) ## Package the helm chart
+	# Package the helm chart
+	$(HELM) package charts/limitador-operator
+
+# GitHub Token with permissions to upload to the release assets
+GITHUB_TOKEN ?= <YOUR-TOKEN>
+# GitHub Release ID, to find the release_id query the GET /repos/{owner}/{repo}/releases/latest or GET /repos/{owner}/{repo}/releases endpoints
+RELEASE_ID ?= <RELEASE-ID>
+# GitHub Release Asset ID, it can be find in the output of the uploaded asset
+ASSET_ID ?= <ASSET-ID>
+# GitHub Release Asset Browser Download URL, it can be find in the output of the uploaded asset
+BROWSER_DOWNLOAD_URL ?= <BROWSER-DOWNLOAD-URL>
+ifeq (0.0.0,$(VERSION))
+CHART_VERSION = $(VERSION)-dev
+else
+CHART_VERSION = $(VERSION)
+endif
+
+.PHONY: helm-upload-package
+helm-upload-package: $(HELM) ## Upload the helm chart package to the GitHub release assets
+	curl -L -s \
+      -X POST \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer $(GITHUB_TOKEN)" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      -H "Content-Type: application/octet-stream" \
+      "https://uploads.github.com/repos/$(ORG)/$(REPO_NAME)/releases/$(RELEASE_ID)/assets?name=chart-limitador-operator-$(CHART_VERSION).tgz" \
+      --data-binary "@limitador-operator-$(CHART_VERSION).tgz"
+
+.PHONY: helm-sync-package
+helm-sync-package: $(HELM) ## Sync the helm chart package to the helm-charts repo
+	curl -L \
+	  -X POST \
+	  -H "Accept: application/vnd.github+json" \
+	  -H "Authorization: Bearer $(GITHUB_TOKEN)" \
+	  -H "X-GitHub-Api-Version: 2022-11-28" \
+	  https://api.github.com/repos/$(ORG)/$(REPO_NAME)/dispatches \
+	  -d '{"event_type":"sync-chart","client_payload":{"chart":limitador-operator,"version":"$(CHART_VERSION)", "asset_id":"$(ASSET_ID)", "browser_download_url": "$(BROWSER_DOWNLOAD_URL)"}}'

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -38,6 +38,8 @@ RELEASE_ID ?= <RELEASE-ID>
 ASSET_ID ?= <ASSET-ID>
 # GitHub Release Asset Browser Download URL, it can be find in the output of the uploaded asset
 BROWSER_DOWNLOAD_URL ?= <BROWSER-DOWNLOAD-URL>
+# Github repo name for the helm charts repository
+HELM_REPO_NAME ?= helm-charts
 ifeq (0.0.0,$(VERSION))
 CHART_VERSION = $(VERSION)-dev
 else
@@ -62,5 +64,5 @@ helm-sync-package: $(HELM) ## Sync the helm chart package to the helm-charts rep
 	  -H "Accept: application/vnd.github+json" \
 	  -H "Authorization: Bearer $(GITHUB_TOKEN)" \
 	  -H "X-GitHub-Api-Version: 2022-11-28" \
-	  https://api.github.com/repos/$(ORG)/$(REPO_NAME)/dispatches \
-	  -d '{"event_type":"sync-chart","client_payload":{"chart":limitador-operator,"version":"$(CHART_VERSION)", "asset_id":"$(ASSET_ID)", "browser_download_url": "$(BROWSER_DOWNLOAD_URL)"}}'
+	  https://api.github.com/repos/$(ORG)/$(HELM_REPO_NAME)/dispatches \
+	  -d '{"event_type":"sync-chart","client_payload":{"chart":"$(REPO_NAME)","version":"$(CHART_VERSION)", "asset_id":"$(ASSET_ID)", "browser_download_url": "$(BROWSER_DOWNLOAD_URL)"}}'

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -32,10 +32,6 @@ helm-package: $(HELM) ## Package the helm chart
 
 # GitHub Token with permissions to upload to the release assets
 GITHUB_TOKEN ?= <YOUR-TOKEN>
-# GitHub Release ID, to find the release_id query the GET /repos/{owner}/{repo}/releases/latest or GET /repos/{owner}/{repo}/releases endpoints
-RELEASE_ID ?= <RELEASE-ID>
-# GitHub Release Asset ID, it can be find in the output of the uploaded asset
-ASSET_ID ?= <ASSET-ID>
 # GitHub Release Asset Browser Download URL, it can be find in the output of the uploaded asset
 BROWSER_DOWNLOAD_URL ?= <BROWSER-DOWNLOAD-URL>
 # Github repo name for the helm charts repository
@@ -46,17 +42,6 @@ else
 CHART_VERSION = $(VERSION)
 endif
 
-.PHONY: helm-upload-package
-helm-upload-package: $(HELM) ## Upload the helm chart package to the GitHub release assets
-	curl -L -s \
-      -X POST \
-      -H "Accept: application/vnd.github+json" \
-      -H "Authorization: Bearer $(GITHUB_TOKEN)" \
-      -H "X-GitHub-Api-Version: 2022-11-28" \
-      -H "Content-Type: application/octet-stream" \
-      "https://uploads.github.com/repos/$(ORG)/$(REPO_NAME)/releases/$(RELEASE_ID)/assets?name=chart-limitador-operator-$(CHART_VERSION).tgz" \
-      --data-binary "@limitador-operator-$(CHART_VERSION).tgz"
-
 .PHONY: helm-sync-package
 helm-sync-package: $(HELM) ## Sync the helm chart package to the helm-charts repo
 	curl -L \
@@ -65,4 +50,4 @@ helm-sync-package: $(HELM) ## Sync the helm chart package to the helm-charts rep
 	  -H "Authorization: Bearer $(GITHUB_TOKEN)" \
 	  -H "X-GitHub-Api-Version: 2022-11-28" \
 	  https://api.github.com/repos/$(ORG)/$(HELM_REPO_NAME)/dispatches \
-	  -d '{"event_type":"sync-chart","client_payload":{"chart":"$(REPO_NAME)","version":"$(CHART_VERSION)", "asset_id":"$(ASSET_ID)", "browser_download_url": "$(BROWSER_DOWNLOAD_URL)"}}'
+	  -d '{"event_type":"sync-chart","client_payload":{"chart":"$(REPO_NAME)","version":"$(CHART_VERSION)", "browser_download_url": "$(BROWSER_DOWNLOAD_URL)"}}'

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -31,7 +31,7 @@ helm-package: $(HELM) ## Package the helm chart
 	$(HELM) package charts/limitador-operator
 
 # GitHub Token with permissions to upload to the release assets
-GITHUB_TOKEN ?= <YOUR-TOKEN>
+HELM_WORKFLOWS_TOKEN ?= <YOUR-TOKEN>
 # GitHub Release Asset Browser Download URL, it can be find in the output of the uploaded asset
 BROWSER_DOWNLOAD_URL ?= <BROWSER-DOWNLOAD-URL>
 # Github repo name for the helm charts repository
@@ -47,7 +47,7 @@ helm-sync-package: $(HELM) ## Sync the helm chart package to the helm-charts rep
 	curl -L \
 	  -X POST \
 	  -H "Accept: application/vnd.github+json" \
-	  -H "Authorization: Bearer $(GITHUB_TOKEN)" \
+	  -H "Authorization: Bearer $(HELM_WORKFLOWS_TOKEN)" \
 	  -H "X-GitHub-Api-Version: 2022-11-28" \
 	  https://api.github.com/repos/$(ORG)/$(HELM_REPO_NAME)/dispatches \
 	  -d '{"event_type":"sync-chart","client_payload":{"chart":"$(REPO_NAME)","version":"$(CHART_VERSION)", "browser_download_url": "$(BROWSER_DOWNLOAD_URL)"}}'


### PR DESCRIPTION
This PR introduces a way to manage a Limitador Operator [Helm Chart](https://helm.sh/). This is not meant to replace the way we are building and delivering our manifests (Kustomize, OLM) but to provide an alternative (complementary) way of delivering the operator.

This early implementation uses Kustomize to create the chart template, instead of creating and maintaining new ones with Helm, to later customize the Helm only settings with its `values.yaml`

**NOTES**

* This chart (and every other operator chart we package in the future: Authorino, DNS, etc) bundles only the operator in the same fashion OLM does.
* The operator version matches the chart version
* This first release doesn't use helm templating, it provides only the manifests previously built by Kustomize.
* The sole repository for all our operator charts will be hosted in [Kuadrant/helm-charts](https://github.com/Kuadrant/helm-charts/).
* The "source of truth" (source code and releasing logic) will be provided in each operator repo, not in the helm charts repository above.
* The release workflow is not fully automated yet, just exposing `workflow_dispatch` it will change in the near future.
* The PR related for the repository is [WIP](https://github.com/Kuadrant/helm-charts/pull/8)
* Documentation will be provided once the repository and other operator charts are tested.
* The steps to try out the repository will be provided in the kuadrant helm charts repo.


**TODO**

* [x] Build manifests with Kustomize
* [x] Install/Uninstall and Upgrade targets
* [x] Adjust Charts mandatory settings
* [x] Decide on chart versioning (if matching operators or keep its own) ---> Same as OLM, same as Operator image
* [x] Github workflow for release package


**Verification Steps**

1. Create a local kind cluster
```sh
make kind-create-cluster
```

2. Deploy (install) the default (`latest`) Limitador Operator chart
```sh
make helm-install
```

3. Verify the installed operator image:
```sh
kubectl get deployments/limitador-operator-controller-manager -n limitador-operator-system -o yaml | grep image:
```

it should return:
```sh
image: quay.io/kuadrant/limitador-operator:latest
```

4. Build new manifests with specific version of the operator
```sh
make helm-build \
            VERSION=0.9.0 \
            LIMITADOR_VERSION=1.4.0
```

5. Upgrade the current installed operator to the freshly built one
```sh
make helm-upgrade
```

6. Check the installed operator image:
```sh
kubectl get deployments/limitador-operator-controller-manager -n limitador-operator-system -o yaml | grep image:
```

it should return:
```sh
image: quay.io/kuadrant/limitador-operator:v0.9.0
```


