### PR TITLE
Gh 668

### DIFF
--- a/bundle/manifests/limitador-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/limitador-operator-controller-manager-metrics-service_v1_service.yaml
@@ -11,6 +11,7 @@ spec:
     port: 8080
     targetPort: metrics
   selector:
+    app: limitador-operator
     control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -144,6 +144,7 @@ spec:
           template:
             metadata:
               labels:
+                app: limitador-operator
                 control-plane: controller-manager
             spec:
               containers:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,6 +21,7 @@ spec:
     metadata:
       labels:
         control-plane: controller-manager
+        app: limitador-operator
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/manager/metrics_service.yaml
+++ b/config/manager/metrics_service.yaml
@@ -13,3 +13,5 @@ spec:
     targetPort: metrics
   selector:
     control-plane: controller-manager
+    app: limitador-operator
+ 

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -15,3 +15,4 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app: limitador-operator

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -12,3 +12,4 @@ spec:
     targetPort: https
   selector:
     control-plane: controller-manager
+    app: limitador-operator

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -3,3 +3,5 @@ kind: ServiceAccount
 metadata:
   name: controller-manager
   namespace: system
+  labels: 
+    app: limitador-operator


### PR DESCRIPTION
WHAT: 
Adding labels to resources as limitador often runs in the same namespace as other operators so we are seeing certain issues with metrics repeating mainly around the service resource. Since its adding a label it shouldn't break things 