### PR TITLE
Helm Chart release workflow adjustments

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -1,4 +1,7 @@
-name: release-helm-chart
+# Description: This workflow is used to release the Helm chart to the GitHub repository. The chart manifests should be already
+# built with the target `helm-build` and the manifests changes already committed to the tag to be released.
+
+name: Release Helm Chart
 on:
 # TODO: The following commented lines should be used depending on the release strategy
 #  release:
@@ -14,10 +17,6 @@ on:
           description: Operator bundle version
           default: 0.0.0
           type: string
-      limitadorVersion:
-        description: Limitador version
-        default: latest
-        type: string
 
 jobs:
   chart_release:
@@ -36,12 +35,6 @@ jobs:
       run: |
         git config user.name "$GITHUB_ACTOR"
         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-    - name: Build the Helm Chart manifests
-      run: |
-        make helm-build \
-          VERSION=${{ inputs.operatorVersion }} \
-          LIMITADOR_VERSION=${{ inputs.limitadorVersion }}
 
     - name: Package Helm Chart
       run: |

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -18,10 +18,6 @@ on:
         description: Limitador version
         default: latest
         type: string
-      releaseId:
-        description: Release ID
-        default: 0
-        type: string
 
 jobs:
   chart_release:

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -45,7 +45,7 @@ jobs:
       id: upload-chart
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: charts/limitador-operator-${{ inputs.operatorVersion }}.tgz
+        file: limitador-operator-${{ inputs.operatorVersion }}.tgz
         asset_name: chart-limitador-operator-${{ inputs.operatorVersion }}.tgz
         tag: ${{ github.ref }}
         overwrite: true


### PR DESCRIPTION
This PR fixes the path to the CI built chart package to be uploaded and removes unused input variables and redundant steps. This addresses too [this comment](https://github.com/Kuadrant/limitador-operator/pull/137#discussion_r1643074922) on the [PR introducing the workflow](https://github.com/Kuadrant/limitador-operator/pull/137).