### PR TITLE
added display version, hash and dirty in logs

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -94,7 +94,7 @@ jobs:
           dockerfiles: |
             ./Dockerfile
           build-args: |
-            GIT_SHA=${{ env.GIT_SHA }}
+            GIT_SHA=${{ github.sha }}
             DIRTY=${{ env.DIRTY }}
       - name: Push Image
         if: ${{ !env.ACT }}

--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -65,25 +65,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
-      - name: Set build arguments
-        run: |
-          GIT_SHA=$(git rev-parse HEAD)
-          GIT_SHA=$$(git rev-parse HEAD) || { \
-            GIT_HASH=$${GIT_SHA:-NO_SHA}; \
-          }; \
-          if [ -z "$$GIT_HASH" ]; then \
-            GIT_DIRTY=$$(git diff --stat); \
-            if [ -n "$$GIT_DIRTY" ]; then \
-              DIRTY="true"; \
-            else \
-              DIRTY="false"; \
-            fi; \
-          else \
-                DIRTY="unknown"; \
-          fi; \
-
-          echo "GIT_SHA=${GIT_SHA}" >> $GITHUB_ENV
-          echo "DIRTY=${DIRTY}" >> $GITHUB_ENV
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2
@@ -95,7 +76,7 @@ jobs:
             ./Dockerfile
           build-args: |
             GIT_SHA=${{ github.sha }}
-            DIRTY=${{ env.DIRTY }}
+            DIRTY="false"
       - name: Push Image
         if: ${{ !env.ACT }}
         id: push-to-quay

--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -76,7 +76,7 @@ jobs:
             ./Dockerfile
           build-args: |
             GIT_SHA=${{ github.sha }}
-            DIRTY="false"
+            DIRTY=false
       - name: Push Image
         if: ${{ !env.ACT }}
         id: push-to-quay

--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -65,6 +65,25 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
+      - name: Set build arguments
+        run: |
+          GIT_SHA=$(git rev-parse HEAD)
+          GIT_SHA=$$(git rev-parse HEAD) || { \
+            GIT_HASH=$${GIT_SHA:-NO_SHA}; \
+          }; \
+          if [ -z "$$GIT_HASH" ]; then \
+            GIT_DIRTY=$$(git diff --stat); \
+            if [ -n "$$GIT_DIRTY" ]; then \
+              DIRTY="true"; \
+            else \
+              DIRTY="false"; \
+            fi; \
+          else \
+                DIRTY="unknown"; \
+          fi; \
+
+          echo "GIT_SHA=${GIT_SHA}" >> $GITHUB_ENV
+          echo "DIRTY=${DIRTY}" >> $GITHUB_ENV
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2
@@ -74,6 +93,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           dockerfiles: |
             ./Dockerfile
+          build-args: |
+            GIT_SHA=${{ env.GIT_SHA }}
+            DIRTY=${{ env.DIRTY }}
       - name: Push Image
         if: ${{ !env.ACT }}
         id: push-to-quay

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,14 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+ARG VERSION
+ARG COMMIT
+ARG DIRTY
+
+ENV VERSION=${VERSION:-unknown}
+ENV COMMIT=${COMMIT:-unknown}
+ENV DIRTY=${DIRTY:-unknown}
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.dirty=${DIRTY}" -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,16 +14,15 @@ COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
+COPY version/ version/
 
 # Build
-ARG VERSION
 ARG COMMIT
 ARG DIRTY
 
-ENV VERSION=${VERSION:-unknown}
 ENV COMMIT=${COMMIT:-unknown}
 ENV DIRTY=${DIRTY:-unknown}
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.dirty=${DIRTY}" -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags "-X main.commit=${COMMIT} -X main.dirty=${DIRTY}" -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,12 @@ COPY pkg/ pkg/
 COPY version/ version/
 
 # Build
-ARG COMMIT
+ARG GIT_SHA
 ARG DIRTY
 
-ENV COMMIT=${COMMIT:-unknown}
+ENV GIT_SHA=${GIT_SHA:-unknown}
 ENV DIRTY=${DIRTY:-unknown}
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags "-X main.commit=${COMMIT} -X main.dirty=${DIRTY}" -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags "-X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -278,22 +278,22 @@ test-unit: clean-cov generate fmt vet ## Run Unit tests.
 	go test $(UNIT_DIRS) -coverprofile $(PROJECT_PATH)/coverage/unit/cover.out -v -timeout 0 $(TEST_PATTERN)
 
 ##@ Build
-build: COMMIT=$(shell git rev-parse HEAD)
+build: GIT_SHA=$(shell git rev-parse HEAD)
 build: DIRTY=$(shell $(check_dirty))
 build: generate fmt vet ## Build manager binary.
-	   go build -ldflags "-X main.commit=${COMMIT} -X main.dirty=${DIRTY}" -o bin/manager main.go
+	   go build -ldflags "-X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" -o bin/manager main.go
 
 run: export LOG_LEVEL = debug
 run: export LOG_MODE = development
-run: COMMIT=$(shell git rev-parse HEAD)
+run: GIT_SHA=$(shell git rev-parse HEAD)
 run: DIRTY=$(shell $(check_dirty))
 run: manifests generate fmt vet ## Run a controller from your host.)
-	go run -ldflags "-X main.commit=${COMMIT} -X main.dirty=${DIRTY}" ./main.go
+	go run -ldflags "-X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" ./main.go
 
-docker-build: COMMIT=$(shell git rev-parse HEAD)
+docker-build: GIT_SHA=$(shell git rev-parse HEAD)
 docker-build: DIRTY=$(shell $(check_dirty))
 docker-build: ## Build docker image with the manager.
-	docker build --build-arg COMMIT=$(COMMIT) --build-arg DIRTY=$(DIRTY) -t $(IMG) .
+	docker build --build-arg GIT_SHA=$(GIT_SHA) --build-arg DIRTY=$(DIRTY) -t $(IMG) .
 
 docker-push: ## Push docker image with the manager.
 	docker push $(IMG)

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ endef
 VERSION ?= 0.0.0
 
 # ldflag variables
-VERSION_LIMITADOR_OPERATOR=0.10.0-dev # change this when version increases
 COMMIT=$(shell git rev-parse HEAD)
 DIRTY=$(shell $(check_dirty))
 
@@ -285,7 +284,7 @@ test-unit: clean-cov generate fmt vet ## Run Unit tests.
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.
-	go build -ldflags "-X main.version=${VERSION_LIMITADOR_OPERATOR} -X main.commit=${COMMIT} -X main.dirty=${DIRTY}" -o bin/manager main.go
+	go build -ldflags "-X main.commit=${COMMIT} -X main.dirty=${DIRTY}" -o bin/manager main.go
 
 run: export LOG_LEVEL = debug
 run: export LOG_MODE = development
@@ -293,7 +292,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 docker-build: ## Build docker image with the manager.
-	docker build --build-arg VERSION=$(VERSION_LIMITADOR_OPERATOR) --build-arg COMMIT=$(COMMIT) --build-arg DIRTY=$(DIRTY) -t $(IMG) .
+	docker build --build-arg COMMIT=$(COMMIT) --build-arg DIRTY=$(DIRTY) -t $(IMG) .
 
 docker-push: ## Push docker image with the manager.
 	docker push $(IMG)

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ define check_dirty
 		else \
 			DIRTY="false"; \
 		fi; \
+	else \
+        DIRTY="unknown"; \
 	fi; \
 	echo $$DIRTY
 endef
@@ -278,20 +280,20 @@ test-unit: clean-cov generate fmt vet ## Run Unit tests.
 	go test $(UNIT_DIRS) -coverprofile $(PROJECT_PATH)/coverage/unit/cover.out -v -timeout 0 $(TEST_PATTERN)
 
 ##@ Build
-build: GIT_SHA=$(shell git rev-parse HEAD)
-build: DIRTY=$(shell $(check_dirty))
+build: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
+build: DIRTY=$(shell $(check_dirty) || echo "unknown")
 build: generate fmt vet ## Build manager binary.
 	   go build -ldflags "-X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" -o bin/manager main.go
 
 run: export LOG_LEVEL = debug
 run: export LOG_MODE = development
-run: GIT_SHA=$(shell git rev-parse HEAD)
-run: DIRTY=$(shell $(check_dirty))
+run: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
+run: DIRTY=$(shell $(check_dirty) || echo "unknown")
 run: manifests generate fmt vet ## Run a controller from your host.)
 	go run -ldflags "-X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" ./main.go
 
-docker-build: GIT_SHA=$(shell git rev-parse HEAD)
-docker-build: DIRTY=$(shell $(check_dirty))
+docker-build: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
+docker-build: DIRTY=$(shell $(check_dirty) || echo "unknown")
 docker-build: ## Build docker image with the manager.
 	docker build --build-arg GIT_SHA=$(GIT_SHA) --build-arg DIRTY=$(DIRTY) -t $(IMG) .
 

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,6 @@ endef
 
 VERSION ?= 0.0.0
 
-# ldflag variables
-COMMIT=$(shell git rev-parse HEAD)
-DIRTY=$(shell $(check_dirty))
-
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
@@ -282,15 +278,20 @@ test-unit: clean-cov generate fmt vet ## Run Unit tests.
 	go test $(UNIT_DIRS) -coverprofile $(PROJECT_PATH)/coverage/unit/cover.out -v -timeout 0 $(TEST_PATTERN)
 
 ##@ Build
-
+build: COMMIT=$(shell git rev-parse HEAD)
+build: DIRTY=$(shell $(check_dirty))
 build: generate fmt vet ## Build manager binary.
-	go build -ldflags "-X main.commit=${COMMIT} -X main.dirty=${DIRTY}" -o bin/manager main.go
+	   go build -ldflags "-X main.commit=${COMMIT} -X main.dirty=${DIRTY}" -o bin/manager main.go
 
 run: export LOG_LEVEL = debug
 run: export LOG_MODE = development
-run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go
+run: COMMIT=$(shell git rev-parse HEAD)
+run: DIRTY=$(shell $(check_dirty))
+run: manifests generate fmt vet ## Run a controller from your host.)
+	go run -ldflags "-X main.commit=${COMMIT} -X main.dirty=${DIRTY}" ./main.go
 
+docker-build: COMMIT=$(shell git rev-parse HEAD)
+docker-build: DIRTY=$(shell $(check_dirty))
 docker-build: ## Build docker image with the manager.
 	docker build --build-arg COMMIT=$(COMMIT) --build-arg DIRTY=$(DIRTY) -t $(IMG) .
 

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func printControllerMetaInfo() {
 	setupLog.Info(fmt.Sprintf("go version: %s", runtime.Version()))
 	setupLog.Info(fmt.Sprintf("go os/arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	setupLog.Info("base logger", "log level", logLevel, "log mode", logMode)
-	setupLog.Info("booting up limitador-operator", "version", version.Version, "commit", commit, "dirty", dirty)
+	setupLog.Info("", "version", version.Version, "commit", commit, "dirty", dirty)
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -45,6 +45,9 @@ var (
 	scheme   = k8sruntime.NewScheme()
 	logLevel = env.GetString("LOG_LEVEL", "info")
 	logMode  = env.GetString("LOG_MODE", "production")
+	version  string
+	commit   string
+	dirty    string
 )
 
 func init() {
@@ -67,6 +70,7 @@ func printControllerMetaInfo() {
 	setupLog.Info(fmt.Sprintf("go version: %s", runtime.Version()))
 	setupLog.Info(fmt.Sprintf("go os/arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	setupLog.Info("base logger", "log level", logLevel, "log mode", logMode)
+	setupLog.Info("booting up limitador-operator", "version", version, "commit", commit, "dirty", dirty)
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ var (
 	scheme   = k8sruntime.NewScheme()
 	logLevel = env.GetString("LOG_LEVEL", "info")
 	logMode  = env.GetString("LOG_MODE", "production")
-	commit   string
+	gitSHA   string
 	dirty    string
 )
 
@@ -72,7 +72,7 @@ func printControllerMetaInfo() {
 	setupLog.Info(fmt.Sprintf("go version: %s", runtime.Version()))
 	setupLog.Info(fmt.Sprintf("go os/arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	setupLog.Info("base logger", "log level", logLevel, "log mode", logMode)
-	setupLog.Info("", "version", version.Version, "commit", commit, "dirty", dirty)
+	setupLog.Info("", "version", version.Version, "commit", gitSHA, "dirty", dirty)
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -38,14 +38,16 @@ import (
 	"github.com/kuadrant/limitador-operator/controllers"
 	"github.com/kuadrant/limitador-operator/pkg/log"
 	"github.com/kuadrant/limitador-operator/pkg/reconcilers"
+
 	//+kubebuilder:scaffold:imports
+	// import version
+	"github.com/kuadrant/limitador-operator/version"
 )
 
 var (
 	scheme   = k8sruntime.NewScheme()
 	logLevel = env.GetString("LOG_LEVEL", "info")
 	logMode  = env.GetString("LOG_MODE", "production")
-	version  string
 	commit   string
 	dirty    string
 )
@@ -70,7 +72,7 @@ func printControllerMetaInfo() {
 	setupLog.Info(fmt.Sprintf("go version: %s", runtime.Version()))
 	setupLog.Info(fmt.Sprintf("go os/arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	setupLog.Info("base logger", "log level", logLevel, "log mode", logMode)
-	setupLog.Info("booting up limitador-operator", "version", version, "commit", commit, "dirty", dirty)
+	setupLog.Info("booting up limitador-operator", "version", version.Version, "commit", commit, "dirty", dirty)
 }
 
 func main() {

--- a/utils/check-git-dirty.sh
+++ b/utils/check-git-dirty.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+if ! command -v git &>/dev/null 
+then
+    echo "git not found..." >&2
+    exit 1
+fi
+
+if output=$(git diff --stat 2>/dev/null)
+then
+[ -n "$output" ] && echo "true" || echo "false"
+else
+    # Not a git repository
+    exit 1
+fi

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package version
+
+var (
+	// This variable is dependent on what the current release is e.g. if it is v0.10.0 then this variable, outside of releases, will be v0.10.1-dev .
+	Version = "0.10.0-dev"
+)


### PR DESCRIPTION
https://github.com/Kuadrant/authorino/issues/471

### What:

Added info log to display version, commit hash and whether the branch was dirty or not on build . 

### Verify:

Run `make build`  and `make local-setup` locally. Without any file changes made the hash should be displayed without appendixed `dirty` flag. Then add a comment to a file to have git detect new changes and re-run the commands checking binary and in-cluster for both respectively.