### PR TITLE
Release button

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,10 +18,6 @@ on:
         description: Limitador Operator replaced version
         default: 0.0.0-alpha
         type: string
-      channels:
-        description: Bundle and catalog channels, comma separated
-        default: preview
-        type: string
       prerelease:
         description: Is the release a pre release?
         required: false
@@ -53,8 +49,7 @@ jobs:
         run: |
           VERSION=${{ inputs.limitadorOperatorVersion }} \
           LIMITADOR_VERSION=${{ inputs.limitadorVersion }} \
-          REPLACES_VERSION=${{ inputs.replacesVersion }} \
-          CHANNELS=${{ inputs.channels }}
+          REPLACES_VERSION=${{ inputs.replacesVersion }}
           make prepare-release
       - name: Commit and push
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,73 @@
+name: Release Operator
+
+on:
+  workflow_dispatch:
+    inputs:
+      gitRef:
+        description: Commit SHA, tag or branch name
+        required: true
+      limitadorOperatorVersion:
+        description: Limitador Operator bundle version
+        default: latest
+        type: string
+      limitadorVersion:
+        description: Limitador service version
+        default: latest
+        type: string
+      replacesVersion:
+        description: Limitador Operator replaced version
+        default: 0.0.0-alpha
+        type: string
+      channels:
+        description: Bundle and catalog channels, comma separated
+        default: preview
+        type: string
+      prerelease:
+        description: Is the release a pre release?
+        required: false
+        type: boolean
+
+jobs:
+  build:
+    name: Release operator
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install gettext-base
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gettext-base
+      - name: Set up Go 1.21.x
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+        id: go
+      - name: Checkout code at git ref
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.gitRef }}
+      - name: Create release branch
+        if: ${{ !startsWith(inputs.gitRef, 'release-v') }}
+        run: |
+          git checkout -b release-v${{ inputs.limitadorOperatorVersion }}
+      - name: Prepare release
+        run: |
+          VERSION=${{ inputs.limitadorOperatorVersion }} \
+          LIMITADOR_VERSION=${{ inputs.limitadorVersion }} \
+          REPLACES_VERSION=${{ inputs.replacesVersion }} \
+          CHANNELS=${{ inputs.channels }}
+          make prepare-release
+      - name: Commit and push
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A && git commit -m "Prepared release v${{ inputs.limitadorOperatorVersion }}"
+          git push origin release-v${{ inputs.limitadorOperatorVersion }}
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: v${{ inputs.limitadorOperatorVersion }}
+          tag_name: v${{ inputs.limitadorOperatorVersion }}
+          body: "**This release enables installations of Limitador v${{ inputs.limitadorVersion }}**"
+          generate_release_notes: true
+          target_commitish: release-v${{ inputs.limitadorOperatorVersion }}
+          prerelease: ${{ inputs.prerelease }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A && git commit -m "Prepared release v${{ inputs.limitadorOperatorVersion }}"
+          git add -A && git commit -m -s "Prepared release v${{ inputs.limitadorOperatorVersion }}"
           git push origin release-v${{ inputs.limitadorOperatorVersion }}
       - name: Create release
         uses: softprops/action-gh-release@v1

--- a/Makefile
+++ b/Makefile
@@ -364,7 +364,7 @@ bundle-push: ## Push the bundle image.
 prepare-release: ## Prepare the manifests for OLM and Helm Chart for a release.
 	$(MAKE) bundle VERSION=$(VERSION) \
 		LIMITADOR_VERSION=$(LIMITADOR_VERSION) \
-		REPLACES_VERSION=$(REPLACES_VERSION) \
+		REPLACES_VERSION=$(REPLACES_VERSION)
 	$(MAKE) helm-build VERSION=$(VERSION) \
 		LIMITADOR_VERSION=$(LIMITADOR_VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,6 @@ prepare-release: ## Prepare the manifests for OLM and Helm Chart for a release.
 	$(MAKE) bundle VERSION=$(VERSION) \
 		LIMITADOR_VERSION=$(LIMITADOR_VERSION) \
 		REPLACES_VERSION=$(REPLACES_VERSION) \
-		CHANNELS=$(CHANNELS)
 	$(MAKE) helm-build VERSION=$(VERSION) \
 		LIMITADOR_VERSION=$(LIMITADOR_VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -360,6 +360,15 @@ bundle-build: ## Build the bundle image.
 bundle-push: ## Push the bundle image.
 	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
 
+.PHONY: prepare-release
+prepare-release: ## Prepare the manifests for OLM and Helm Chart for a release.
+	$(MAKE) bundle VERSION=$(VERSION) \
+		LIMITADOR_VERSION=$(LIMITADOR_VERSION) \
+		REPLACES_VERSION=$(REPLACES_VERSION) \
+		CHANNELS=$(CHANNELS)
+	$(MAKE) helm-build VERSION=$(VERSION) \
+		LIMITADOR_VERSION=$(LIMITADOR_VERSION)
+
 ##@ Misc
 
 .PHONY: local-env-setup

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,48 @@
+# How to release Limitador Operator
+
+## Process
+
+To release a version _“v0.W.Z”_ of Limitador Operator in GitHub and Quay.io, follow these steps:
+
+1. Pick a stable (released) version _“v0.X.Y”_ of the operand known to be compatible with operator’s image for _“v0.W.Z_”;
+   if needed, [make a release of the operand first](https://github.com/Kuadrant/limitador/blob/main/RELEASE.md).
+
+2. Run the GHA [Release operator](https://github.com/Kuadrant/limitador-operator/actions/workflows/release.yaml); make
+   sure to fill all the fields:
+
+    * Branch containing the release workflow file – default: `main`
+    * Commit SHA or branch name of the operator to release – usually: `main`
+    * Operator version to release (without prefix) – i.e. `0.W.Z`
+    * Limitador version the operator enables installations of (without prefix) – i.e. `0.X.Y`
+    * Operator replaced version (without prefix) – i.e. `0.P.Q`
+    * If the release is a prerelease
+
+3. Run the GHA [Build and push images](https://github.com/Kuadrant/limitador-operator/actions/workflows/build-images-base.yaml)
+   for the _“v0.W.Z”_ tag, specifying ‘Limitador version’ equals to _“0.X.Y”_. This will cause the
+   new images (bundle and catalog included) to be built and pushed to the corresponding repos in
+   [quay.io/kuadrant](https://quay.io/organization/kuadrant).
+
+
+### Publishing the Operator in OpenShift Community Operators
+Open a PR in the [OpenShift Community Operators repo](http://github.com/redhat-openshift-ecosystem/community-operators-prod)
+([example](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/1595) |
+[docs](https://redhat-openshift-ecosystem.github.io/community-operators-prod/operator-release-process/)).
+
+The usual steps are:
+
+1. Start a new branch named `limitador-operator-v0.W.Z`
+
+2. Create a new directory `operators/limitador-operator/0.W.Z` containing:
+
+    * Copy the bundle files from `github.com/kuadrant/limitador-operator/tree/v0.W.Z/bundle`
+    * Copy `github.com/kuadrant/limitador-operator/tree/v0.W.Z/bundle.Dockerfile` with the proper fix to the COPY commands
+      (i.e. remove /bundle from the paths)
+
+### Publishing the Operator in Kubernetes Community Operators (OperatorHub.io)
+
+1. Open a PR in the [Kubernetes Community Operators repo](https://github.com/k8s-operatorhub/community-operators)
+   ([example](https://github.com/k8s-operatorhub/community-operators/pull/1655) | [docs](https://operatorhub.io/contribute)).
+
+2. The usual steps are the same as for the
+   [OpenShift Community Operators](https://docs.google.com/document/d/1tLveyv8Zwe0wKyfUTWOlEnFeMB5aVGqIVDUjVYWax0U/edit#heading=h.b5tapxn4sbk5)
+   hub.


### PR DESCRIPTION
This PR introduces a new workflow for crafting a release, following the pattern used in [Authorino Operator](https://github.com/Kuadrant/authorino-operator/blob/main/.github/workflows/release.yaml). It makes it convenient to trigger the workflow manually without the need to go through the process of creating a branch and manually triggering the make targets, committing and tagging.

It includes the building of both OLM manifests and Helm Charts.