### PR TITLE
Missing info manifests

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -23,6 +23,10 @@ on:
         description: Bundle and catalog channels, comma separated
         default: preview
         type: string
+      defaultChannel:
+        description: Bundle default channel
+        default: preview
+        type: string
       quayImageExpiry:
         description: When to expire the built quay images. The time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively, from the time the image is built.
         default: never
@@ -47,6 +51,10 @@ on:
         type: string
       channels:
         description: Bundle and catalog channels, comma separated
+        default: preview
+        type: string
+      defaultChannel:
+        description: Bundle default channel
         default: preview
         type: string
       quayImageExpiry:
@@ -131,6 +139,7 @@ jobs:
             IMAGE_TAG=${{ inputs.operatorTag }} \
             LIMITADOR_VERSION=${{ inputs.limitadorVersion }} \
             REPLACES_VERSION=${{ inputs.replacesVersion }} \
+            DEFAULT_CHANNEL=${{ inputs.defaultChannel }} \
             CHANNELS=${{ inputs.channels }}
       - name: Add git sha tag for the main branch
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
@@ -180,7 +189,7 @@ jobs:
             VERSION=${{ env.VERSION }} IMAGE_TAG=${{ inputs.operatorTag }} \
             LIMITADOR_VERSION=${{ inputs.limitadorVersion }} \
             REPLACES_VERSION=${{ inputs.replacesVersion }} \
-            CHANNELS=${{ inputs.channels }}
+            DEFAULT_CHANNEL=${{ inputs.defaultChannel }}
       - name: Install qemu dependency
         run: |
           sudo apt-get update

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,8 @@ VERSION ?= 0.0.0
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
 # - use the CHANNELS as arg of the bundle target (e.g make bundle CHANNELS=candidate,fast,stable)
 # - use environment variables to overwrite this value (e.g export CHANNELS="candidate,fast,stable")
-ifneq ($(origin CHANNELS), undefined)
+CHANNELS ?= alpha
 BUNDLE_CHANNELS := --channels=$(CHANNELS)
-endif
 
 # DEFAULT_CHANNEL defines the default channel used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g DEFAULT_CHANNEL = "stable")

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,8 @@ endif
 # To re-generate a bundle for any other default channel without changing the default setup, you can:
 # - use the DEFAULT_CHANNEL as arg of the bundle target (e.g make bundle DEFAULT_CHANNEL=stable)
 # - use environment variables to overwrite this value (e.g export DEFAULT_CHANNEL="stable")
-ifneq ($(origin DEFAULT_CHANNEL), undefined)
+DEFAULT_CHANNEL ?= alpha
 BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
-endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # Address of the container registry

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,6 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=limitador-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.32.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3

--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/limitador-operator:latest
-    createdAt: "2024-07-05T11:06:08Z"
+    createdAt: "2024-09-24T13:57:26Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/limitador-operator

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,6 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: limitador-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.32.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3

--- a/doc/development.md
+++ b/doc/development.md
@@ -79,13 +79,17 @@ The `make bundle` target accepts the following variables:
 | `IMG`                     | Operator image URL   | `quay.io/kuadrant/limitador-operator:latest` |                                                                          |
 | `VERSION`                 | Bundle version       | `0.0.0`                                      |                                                                          |
 | `RELATED_IMAGE_LIMITADOR` | Limitador bundle URL | `quay.io/kuadrant/limitador:latest`          | `LIMITADOR_VERSION` var could be use to build this URL providing the tag |
+| `CHANNELS`                | Bundle channels used in the bundle, comma separated                 | `alpha`                                                                  |
+| `DEFAULT_CHANNEL`         | The default channel used in the bundle                              | `alpha`                                                                  |
 
 * Build the bundle manifests
 
 ```bash
 make bundle [IMG=quay.io/kuadrant/limitador-operator:latest] \
             [VERSION=0.0.0] \
-            [RELATED_IMAGE_LIMITADOR=quay.io/kuadrant/limitador:latest]
+            [RELATED_IMAGE_LIMITADOR=quay.io/kuadrant/limitador:latest] \
+            [CHANNELS=alpha] \
+            [DEFAULT_CHANNEL=alpha]
 ```
 
 * Build the bundle image from the manifests

--- a/doc/development.md
+++ b/doc/development.md
@@ -120,12 +120,12 @@ The `make catalog` target accepts the following variables:
 |-----------------------|---------------------------|-----------------------------------------------------|
 | `BUNDLE_IMG`          | Operator bundle image URL | `quay.io/kuadrant/limitador-operator-bundle:latest` |
 | `REPLACES_VERSION`    | Previous operator version | `0.0.0-alpha`                                       |
-| `CHANNELS`            | Catalog channels          | `preview`                                           |
+| `DEFAULT_CHANNEL`     | Catalog default channel   | `alpha`                                             |
 
 ```sh
 make catalog [BUNDLE_IMG=quay.io/kuadrant/limitador-operator-bundle:latest] \
              [REPLACES_VERSION=0.0.0-alpha] \
-             [CHANNELS=preview]
+             [DEFAULT_CHANNEL=alpha]
 ```
 
 * Build the catalog image from the manifests

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -27,14 +27,14 @@ $(CATALOG_FILE): $(OPM) $(YQ)
 	@echo "************************************************************"
 	@echo Build limitador operator catalog
 	@echo
-	@echo BUNDLE_IMG					= $(BUNDLE_IMG)
-	@echo REPLACES_VERSION				= $(REPLACES_VERSION)
-	@echo CHANNELS						= $(CHANNELS)
+	@echo BUNDLE_IMG                   = $(BUNDLE_IMG)
+	@echo REPLACES_VERSION             = $(REPLACES_VERSION)
+	@echo CHANNEL                      = $(DEFAULT_CHANNEL)
 	@echo "************************************************************"
 	@echo
 	@echo Please check this matches your expectations and override variables if needed.
 	@echo
-	$(PROJECT_PATH)/utils/generate-catalog.sh $(OPM) $(YQ) $(BUNDLE_IMG) $@ $(REPLACES_VERSION) $(CHANNELS)
+	$(PROJECT_PATH)/utils/generate-catalog.sh $(OPM) $(YQ) $(BUNDLE_IMG) $@ $(REPLACES_VERSION) $(DEFAULT_CHANNEL)
 
 .PHONY: catalog
 catalog: $(OPM) ## Generate catalog content and validate.

--- a/utils/generate-catalog.sh
+++ b/utils/generate-catalog.sh
@@ -15,7 +15,7 @@ YQ="${2?:Error \$YQ not set. Bye}"
 BUNDLE_IMG="${3?:Error \$BUNDLE_IMG not set. Bye}"
 CATALOG_FILE="${4?:Error \$CATALOG_FILE not set. Bye}"
 REPLACES_VERSION="${5:-$DEFAULT_REPLACES_VERSION}"
-CHANNELS="${6:-$DEFAULT_CHANNEL}"
+CHANNEL="${6:-$DEFAULT_CHANNEL}"
 
 CATALOG_FILE_BASEDIR="$( cd "$( dirname "$(realpath ${CATALOG_FILE})" )" && pwd )"
 CATALOG_BASEDIR="$( cd "$( dirname "$(realpath ${CATALOG_FILE_BASEDIR})" )" && pwd )"
@@ -31,13 +31,13 @@ touch ${CATALOG_FILE}
 # Limitador Operator
 ###
 # Add the package
-${OPM} init limitador-operator --default-channel=${CHANNELS} --output yaml >> ${CATALOG_FILE}
+${OPM} init limitador-operator --default-channel=${CHANNEL} --output yaml >> ${CATALOG_FILE}
 # Add a bundles to the Catalog
 cat ${TMP_DIR}/limitador-operator-bundle.yaml >> ${CATALOG_FILE}
 # Add a channel entry for the bundle
 V=`${YQ} eval '.name' ${TMP_DIR}/limitador-operator-bundle.yaml` \
 REPLACES=limitador-operator.v${REPLACES_VERSION} \
-CHANNELS=${CHANNELS} \
-    ${YQ} eval '(.entries[0].name = strenv(V)) | (.entries[0].replaces = strenv(REPLACES)) | (.name = strenv(CHANNELS))' ${CATALOG_BASEDIR}/limitador-operator-channel-entry.yaml >> ${CATALOG_FILE}
+CHANNEL=${CHANNEL} \
+    ${YQ} eval '(.entries[0].name = strenv(V)) | (.entries[0].replaces = strenv(REPLACES)) | (.name = strenv(CHANNEL))' ${CATALOG_BASEDIR}/limitador-operator-channel-entry.yaml >> ${CATALOG_FILE}
 
 rm -rf $TMP_DIR


### PR DESCRIPTION
### What

* Adding the default channel to bundle annotations
* Custom catalog do not need multiple channels, only one. Taking the default channel as the one. In the future we could generate catalog with multiple channels and the bundle being member of all of those. But not use today.