### PR TITLE
 🔥 "replaces" from bundle 

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -15,10 +15,6 @@ on:
         description: Limitador version
         default: latest
         type: string
-      replacesVersion:
-        description: Limitador Operator replaced version
-        default: 0.0.0-alpha
-        type: string
       channels:
         description: Bundle and catalog channels, comma separated
         default: preview
@@ -44,10 +40,6 @@ on:
       limitadorVersion:
         description: Limitador version
         default: latest
-        type: string
-      replacesVersion:
-        description: Limitador Operator replaced version
-        default: 0.0.0-alpha
         type: string
       channels:
         description: Bundle and catalog channels, comma separated
@@ -138,7 +130,6 @@ jobs:
             VERSION=${{ env.VERSION }} \
             IMAGE_TAG=${{ inputs.operatorTag }} \
             LIMITADOR_VERSION=${{ inputs.limitadorVersion }} \
-            REPLACES_VERSION=${{ inputs.replacesVersion }} \
             DEFAULT_CHANNEL=${{ inputs.defaultChannel }} \
             CHANNELS=${{ inputs.channels }}
       - name: Add git sha tag for the main branch
@@ -188,7 +179,6 @@ jobs:
             REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} \
             VERSION=${{ env.VERSION }} IMAGE_TAG=${{ inputs.operatorTag }} \
             LIMITADOR_VERSION=${{ inputs.limitadorVersion }} \
-            REPLACES_VERSION=${{ inputs.replacesVersion }} \
             DEFAULT_CHANNEL=${{ inputs.defaultChannel }}
       - name: Install qemu dependency
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,10 +14,6 @@ on:
         description: Limitador service version
         default: latest
         type: string
-      replacesVersion:
-        description: Limitador Operator replaced version
-        default: 0.0.0-alpha
-        type: string
       prerelease:
         description: Is the release a pre release?
         required: false
@@ -49,7 +45,6 @@ jobs:
         run: |
           VERSION=${{ inputs.limitadorOperatorVersion }} \
           LIMITADOR_VERSION=${{ inputs.limitadorVersion }} \
-          REPLACES_VERSION=${{ inputs.replacesVersion }}
           make prepare-release
       - name: Commit and push
         run: |

--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,6 @@ INTEGRATION_COVER_PKGS := ./pkg/...,./controllers/...,./api/...
 INTEGRATION_TEST_NUM_CORES ?= 4
 INTEGRATION_TEST_NUM_PROCESSES ?= 10
 
-# Limitador Operator replaced version
-DEFAULT_REPLACES_VERSION = 0.0.0-alpha
-REPLACES_VERSION ?= $(DEFAULT_REPLACES_VERSION)
-
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -337,7 +333,6 @@ bundle: $(KUSTOMIZE) $(OPERATOR_SDK) $(YQ) manifests ## Generate bundle manifest
 	V="limitador-operator.v$(BUNDLE_VERSION)" $(YQ) eval '.metadata.name = strenv(V)' -i config/manifests/bases/limitador-operator.clusterserviceversion.yaml
 	V="$(BUNDLE_VERSION)" $(YQ) eval '.spec.version = strenv(V)' -i config/manifests/bases/limitador-operator.clusterserviceversion.yaml
 	V="$(IMG)" $(YQ) eval '.metadata.annotations.containerImage = strenv(V)' -i config/manifests/bases/limitador-operator.clusterserviceversion.yaml
-	V="limitador-operator.v$(REPLACES_VERSION)" $(YQ) eval '.spec.replaces = strenv(V)' -i config/manifests/bases/limitador-operator.clusterserviceversion.yaml
 	# Generate bundle
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(BUNDLE_VERSION) $(BUNDLE_METADATA_OPTS)
 	# Validate bundle manifests
@@ -368,7 +363,6 @@ bundle-push: ## Push the bundle image.
 prepare-release: ## Prepare the manifests for OLM and Helm Chart for a release.
 	$(MAKE) bundle VERSION=$(VERSION) \
 		LIMITADOR_VERSION=$(LIMITADOR_VERSION) \
-		REPLACES_VERSION=$(REPLACES_VERSION)
 	$(MAKE) helm-build VERSION=$(VERSION) \
 		LIMITADOR_VERSION=$(LIMITADOR_VERSION)
 

--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -242,5 +242,4 @@ spec:
   relatedImages:
   - image: quay.io/kuadrant/limitador:latest
     name: limitador
-  replaces: limitador-operator.v0.0.0-alpha
   version: 0.0.0

--- a/config/manifests/bases/limitador-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/limitador-operator.clusterserviceversion.yaml
@@ -53,5 +53,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/limitador-operator
-  replaces: limitador-operator.v0.0.0-alpha
   version: 0.0.0

--- a/doc/development.md
+++ b/doc/development.md
@@ -123,13 +123,10 @@ The `make catalog` target accepts the following variables:
 | **Makefile Variable** | **Description**           | **Default value**                                   |
 |-----------------------|---------------------------|-----------------------------------------------------|
 | `BUNDLE_IMG`          | Operator bundle image URL | `quay.io/kuadrant/limitador-operator-bundle:latest` |
-| `REPLACES_VERSION`    | Previous operator version | `0.0.0-alpha`                                       |
 | `DEFAULT_CHANNEL`     | Catalog default channel   | `alpha`                                             |
 
 ```sh
-make catalog [BUNDLE_IMG=quay.io/kuadrant/limitador-operator-bundle:latest] \
-             [REPLACES_VERSION=0.0.0-alpha] \
-             [DEFAULT_CHANNEL=alpha]
+make catalog [BUNDLE_IMG=quay.io/kuadrant/limitador-operator-bundle:latest] [DEFAULT_CHANNEL=alpha]
 ```
 
 * Build the catalog image from the manifests

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -28,13 +28,12 @@ $(CATALOG_FILE): $(OPM) $(YQ)
 	@echo Build limitador operator catalog
 	@echo
 	@echo BUNDLE_IMG                   = $(BUNDLE_IMG)
-	@echo REPLACES_VERSION             = $(REPLACES_VERSION)
 	@echo CHANNEL                      = $(DEFAULT_CHANNEL)
 	@echo "************************************************************"
 	@echo
 	@echo Please check this matches your expectations and override variables if needed.
 	@echo
-	$(PROJECT_PATH)/utils/generate-catalog.sh $(OPM) $(YQ) $(BUNDLE_IMG) $@ $(REPLACES_VERSION) $(DEFAULT_CHANNEL)
+	$(PROJECT_PATH)/utils/generate-catalog.sh $(OPM) $(YQ) $(BUNDLE_IMG) $@ $(DEFAULT_CHANNEL)
 
 .PHONY: catalog
 catalog: $(OPM) ## Generate catalog content and validate.

--- a/utils/generate-catalog.sh
+++ b/utils/generate-catalog.sh
@@ -7,15 +7,13 @@ set -euo pipefail
 ### CONSTANTS
 # Used as well in the subscription object
 DEFAULT_CHANNEL=preview
-DEFAULT_REPLACES_VERSION=0.0.0-alpha
 ###
 
 OPM="${1?:Error \$OPM not set. Bye}"
 YQ="${2?:Error \$YQ not set. Bye}"
 BUNDLE_IMG="${3?:Error \$BUNDLE_IMG not set. Bye}"
 CATALOG_FILE="${4?:Error \$CATALOG_FILE not set. Bye}"
-REPLACES_VERSION="${5:-$DEFAULT_REPLACES_VERSION}"
-CHANNEL="${6:-$DEFAULT_CHANNEL}"
+CHANNEL="${5:-$DEFAULT_CHANNEL}"
 
 CATALOG_FILE_BASEDIR="$( cd "$( dirname "$(realpath ${CATALOG_FILE})" )" && pwd )"
 CATALOG_BASEDIR="$( cd "$( dirname "$(realpath ${CATALOG_FILE_BASEDIR})" )" && pwd )"
@@ -36,8 +34,7 @@ ${OPM} init limitador-operator --default-channel=${CHANNEL} --output yaml >> ${C
 cat ${TMP_DIR}/limitador-operator-bundle.yaml >> ${CATALOG_FILE}
 # Add a channel entry for the bundle
 V=`${YQ} eval '.name' ${TMP_DIR}/limitador-operator-bundle.yaml` \
-REPLACES=limitador-operator.v${REPLACES_VERSION} \
 CHANNEL=${CHANNEL} \
-    ${YQ} eval '(.entries[0].name = strenv(V)) | (.entries[0].replaces = strenv(REPLACES)) | (.name = strenv(CHANNEL))' ${CATALOG_BASEDIR}/limitador-operator-channel-entry.yaml >> ${CATALOG_FILE}
+    ${YQ} eval '(.entries[0].name = strenv(V)) | (.name = strenv(CHANNEL))' ${CATALOG_BASEDIR}/limitador-operator-channel-entry.yaml >> ${CATALOG_FILE}
 
 rm -rf $TMP_DIR


### PR DESCRIPTION
For OLM from custom catalogs, replaces does not make sense as the catalog has only one bundle.

For OLM  from public catalogs, we switched recently to `semver-mode`, so the "replaces" are automatically computed by OLM https://github.com/k8s-operatorhub/community-operators/pull/5074/files#diff-065802dd933715bcbb9102cf0ec632f16e00b47c9aafda66865c08e3c00fbda2R1

Helm charts not affected (AFAICT)

In conclusion, no need for `replaces` field. 🔥 to it.