### PR TITLE
Add CRDs printcolumns

### DIFF
--- a/api/v1alpha1/limitador_types.go
+++ b/api/v1alpha1/limitador_types.go
@@ -114,6 +114,8 @@ type LimitadorSpec struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`,description="Limitador Ready",priority=2
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Limitador is the Schema for the limitadors API
 type Limitador struct {

--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/limitador-operator:latest
-    createdAt: "2024-10-04T07:52:06Z"
+    createdAt: "2024-10-18T10:24:00Z"
     description: The Limitador operator installs and maintains limitador instances
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/limitador.kuadrant.io_limitadors.yaml
+++ b/bundle/manifests/limitador.kuadrant.io_limitadors.yaml
@@ -14,7 +14,16 @@ spec:
     singular: limitador
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Limitador Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Limitador is the Schema for the limitadors API

--- a/charts/limitador-operator/templates/manifests.yaml
+++ b/charts/limitador-operator/templates/manifests.yaml
@@ -15,7 +15,16 @@ spec:
     singular: limitador
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Limitador Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Limitador is the Schema for the limitadors API

--- a/config/crd/bases/limitador.kuadrant.io_limitadors.yaml
+++ b/config/crd/bases/limitador.kuadrant.io_limitadors.yaml
@@ -14,7 +14,16 @@ spec:
     singular: limitador
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Limitador Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Limitador is the Schema for the limitadors API


### PR DESCRIPTION
### What

This PR adds new columns with status and age information to kubectl get output with -o wide option.

### Verification steps

dev setup

```
make local-setup
```
```yaml
k apply -f - <<EOF
---
apiVersion: limitador.kuadrant.io/v1alpha1
kind: Limitador
metadata:
  name: limitador
spec: {}
EOF
```

Check Limitador columuns

```sh
kubectl get limitador -A -o wide
```
The expected output should contain `READY` and `AGE` columns

```
NAMESPACE   NAME        READY   AGE
default     limitador   True    52s
```