### PR TITLE
Preparing info for ArtifactHub.io

### DIFF
--- a/charts/limitador-operator/Chart.yaml
+++ b/charts/limitador-operator/Chart.yaml
@@ -23,3 +23,37 @@ maintainers:
     name: Didier Di Cesare
   - email: eastizle@redhat.com
     name: Eguzki Astiz Lezaun
+annotations:
+  artifacthub.io/category: security
+  artifacthub.io/crds: |
+    - kind: Limitador
+      version: v1alpha1
+      name: limitadors.limitador.kuadrant.io
+      displayName: Limitador
+      description: Configures an instance of Limitador Service and defines its limits.
+  artifacthub.io/crdsExamples: |
+    - apiVersion: limitador.kuadrant.io/v1alpha1
+      kind: Limitador
+      metadata:
+        name: limitador-sample
+      spec:
+          listener:
+            http:
+              port: 8080
+            grpc:
+              port: 8081
+          limits:
+            - conditions: ["get_toy == 'yes'"]
+              max_value: 2
+              namespace: toystore-app
+              seconds: 30
+              variables: []
+              name: "toy_get_route"
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Kuadrant
+      url: https://kuadrant.io
+    - name: Github
+      url: https://github.com/Kuadrant/limitador-operator
+  artifacthub.io/operator: "true"
+  artifacthub.io/operatorCapabilities: Basic Install


### PR DESCRIPTION
In order to be able to publish our Helm Charts in ArtifactHub.io and display valuable information in their repo site, we should provide some metadata described in https://artifacthub.io/docs/topics/annotations/helm/