### PR TITLE
Helm docs

### DIFF
--- a/charts/limitador-operator/Chart.yaml
+++ b/charts/limitador-operator/Chart.yaml
@@ -16,6 +16,7 @@ kubeVersion: ">=1.19.0-0"
 type: application
 # The version will be properly set when the chart is released matching the operator version
 version: "0.0.0"
+appVersion: "0.0.0"
 maintainers:
   - email: asnaps@redhat.com
     name: Alex Snaps

--- a/charts/limitador-operator/README.md
+++ b/charts/limitador-operator/README.md
@@ -1,0 +1,21 @@
+# Limitador Operator
+
+This is the Helm Chart to install the official Limitador Kubernetes Operator
+
+## Installation
+
+```sh
+helm repo add kuadrant https://kuadrant.io/helm-charts/ --force-update
+helm install \
+ limitador-operator kuadrant/limitador-operator \
+ --create-namespace \
+ --namespace limitador-system
+```
+
+### Parameters
+
+**Coming soon!** At the moment, there's no configuration parameters exposed.
+
+## Usage
+
+Read the documentation and user guides in the [Getting Started guide](https://github.com/Kuadrant/limitador/?tab=readme-ov-file#getting-started).

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -9,6 +9,7 @@ helm-build: $(KUSTOMIZE) $(OPERATOR_SDK) $(YQ) manifests ## Build the helm chart
 	# Build the helm chart templates from kustomize manifests
 	$(KUSTOMIZE) build config/helm > charts/limitador-operator/templates/manifests.yaml
 	V="$(VERSION)" $(YQ) eval '.version = strenv(V)' -i charts/limitador-operator/Chart.yaml
+	V="$(VERSION)" $(YQ) eval '.appVersion = strenv(V)' -i charts/limitador-operator/Chart.yaml
 
 .PHONY: helm-install
 helm-install: $(HELM) ## Install the helm chart


### PR DESCRIPTION
* Helm documentation displayed under the chart page in AritfactHub.io. Needed for the `Official` badge.
* appVersion added in order to shown in helm cli