### PR TITLE
Signing Helm packages

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Package Helm Chart
       run: |
         GPG_KEY_UID="Kuadrant Development Team" \
-        make helm-package
+        make helm-package-sign
 
     - name: Parse Tag
       run: |

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Configure GPG Key
       run: |
-        echo -n "$GPG_SIGNING_KEY" | base64 -d | gpg --import
+        echo -n "$GPG_SIGNING_KEY" | base64 -d > ~/.gnupg/pubring.gpg
       env:
         GPG_SIGNING_KEY: ${{ secrets.HELM_CHARTS_SIGNING_KEY }}
 

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -30,9 +30,14 @@ jobs:
         git config user.name "$GITHUB_ACTOR"
         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+    - name: Configure GPG Key
+      run: |
+        echo -n "$GPG_SIGNING_KEY" | base64 -d | gpg --import
+      env:
+        GPG_SIGNING_KEY: ${{ secrets.HELM_CHARTS_SIGNING_KEY }}
+
     - name: Package Helm Chart
       run: |
-        GPG_KEYRING_BASE64=${{ secrets.HELM_CHARTS_SIGNING_KEY }} \
         GPG_KEY_UID="Kuadrant Development Team" \
         make helm-package
 

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -51,6 +51,16 @@ jobs:
         tag: ${{ github.ref }}
         overwrite: true
 
+    - name: Upload provenance file to GitHub Release
+      uses: svenstaro/upload-release-action@v2
+      id: upload-prov-file
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: limitador-operator-${{ env.OPERATOR_VERSION }}.tgz.prov
+        asset_name: chart-limitador-operator-${{ env.OPERATOR_VERSION }}.tgz.prov
+        tag: ${{ env.OPERATOR_TAG }}
+        overwrite: true
+
     - name: Sync Helm Chart with repository
       run: |
         make helm-sync-package-created \

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -32,6 +32,8 @@ jobs:
 
     - name: Package Helm Chart
       run: |
+        GPG_KEYRING_BASE64=${{ secrets.HELM_CHARTS_SIGNING_KEY }} \
+        GPG_KEY_UID="Kuadrant Development Team" \
         make helm-package
 
     - name: Parse Tag

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ bin
 *.swo
 *~
 
+# Helm chart packages
+*operator*.tgz*
+
 # controller-runtime testenv binaries
 testbin
 

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -42,7 +42,7 @@ GPG_KEY_UID ?= 'Kuadrant Development Team'
 .PHONY: helm-package-sign
 helm-package-sign: $(HELM) ## Package the helm chart and GPG sign it
 	# Package the helm chart and sign it
-	$(HELM) package --sign --key $(GPG_KEY_UID) $(CHART_DIRECTORY)
+	$(HELM) package --sign --key "$(GPG_KEY_UID)" $(CHART_DIRECTORY)
 
 # GitHub Token with permissions to upload to the release assets
 HELM_WORKFLOWS_TOKEN ?= <YOUR-TOKEN>

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -1,5 +1,10 @@
 ##@ Helm Charts
 
+# Chart name
+CHART_NAME ?= limitador-operator
+# Chart directory
+CHART_DIRECTORY ?= charts/$(CHART_NAME)
+
 .PHONY: helm-build
 helm-build: $(KUSTOMIZE) $(OPERATOR_SDK) $(YQ) manifests ## Build the helm chart from kustomize manifests
 	# Set desired operator image and related limitador image
@@ -7,29 +12,29 @@ helm-build: $(KUSTOMIZE) $(OPERATOR_SDK) $(YQ) manifests ## Build the helm chart
 	# Replace the controller image
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	# Build the helm chart templates from kustomize manifests
-	$(KUSTOMIZE) build config/helm > charts/limitador-operator/templates/manifests.yaml
-	V="$(VERSION)" $(YQ) eval '.version = strenv(V)' -i charts/limitador-operator/Chart.yaml
-	V="$(VERSION)" $(YQ) eval '.appVersion = strenv(V)' -i charts/limitador-operator/Chart.yaml
+	$(KUSTOMIZE) build config/helm > $(CHART_DIRECTORY)/templates/manifests.yaml
+	V="$(VERSION)" $(YQ) eval '.version = strenv(V)' -i $(CHART_DIRECTORY)/Chart.yaml
+	V="$(VERSION)" $(YQ) eval '.appVersion = strenv(V)' -i $(CHART_DIRECTORY)/Chart.yaml
 
 .PHONY: helm-install
 helm-install: $(HELM) ## Install the helm chart
 	# Install the helm chart in the cluster
-	$(HELM) install limitador-operator charts/limitador-operator
+	$(HELM) install $(CHART_NAME) $(CHART_DIRECTORY)
 
 .PHONY: helm-uninstall
 helm-uninstall: $(HELM) ## Uninstall the helm chart
 	# Uninstall the helm chart from the cluster
-	$(HELM) uninstall limitador-operator
+	$(HELM) uninstall $(CHART_NAME)
 
 .PHONY: helm-upgrade
 helm-upgrade: $(HELM) ## Upgrade the helm chart
 	# Upgrade the helm chart in the cluster
-	$(HELM) upgrade limitador-operator charts/limitador-operator
+	$(HELM) upgrade $(CHART_NAME) $(CHART_DIRECTORY)
 
 .PHONY: helm-package
 helm-package: $(HELM) ## Package the helm chart
 	# Package the helm chart
-	$(HELM) package charts/limitador-operator
+	$(HELM) package $(CHART_DIRECTORY)
 
 # GitHub Token with permissions to upload to the release assets
 HELM_WORKFLOWS_TOKEN ?= <YOUR-TOKEN>
@@ -51,7 +56,7 @@ helm-sync-package-created: ## Sync the helm chart package to the helm-charts rep
 	  -H "Authorization: Bearer $(HELM_WORKFLOWS_TOKEN)" \
 	  -H "X-GitHub-Api-Version: 2022-11-28" \
 	  https://api.github.com/repos/$(ORG)/$(HELM_REPO_NAME)/dispatches \
-	  -d '{"event_type":"chart-created","client_payload":{"chart":"$(REPO_NAME)","version":"$(CHART_VERSION)", "browser_download_url": "$(BROWSER_DOWNLOAD_URL)"}}'
+	  -d '{"event_type":"chart-created","client_payload":{"chart":"$(CHART_NAME)","version":"$(CHART_VERSION)", "browser_download_url": "$(BROWSER_DOWNLOAD_URL)"}}'
 
 .PHONY: helm-sync-package-deleted
 helm-sync-package-deleted: ## Sync the deleted helm chart package to the helm-charts repo
@@ -61,4 +66,4 @@ helm-sync-package-deleted: ## Sync the deleted helm chart package to the helm-ch
 	  -H "Authorization: Bearer $(HELM_WORKFLOWS_TOKEN)" \
 	  -H "X-GitHub-Api-Version: 2022-11-28" \
 	  https://api.github.com/repos/$(ORG)/$(HELM_REPO_NAME)/dispatches \
-	  -d '{"event_type":"chart-deleted","client_payload":{"chart":"$(REPO_NAME)","version":"$(CHART_VERSION)"}}'
+	  -d '{"event_type":"chart-deleted","client_payload":{"chart":"$(CHART_NAME)","version":"$(CHART_VERSION)"}}'

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -31,18 +31,18 @@ helm-upgrade: $(HELM) ## Upgrade the helm chart
 	# Upgrade the helm chart in the cluster
 	$(HELM) upgrade $(CHART_NAME) $(CHART_DIRECTORY)
 
+.PHONY: helm-package
+helm-package: $(HELM) ## Package the helm chart
+	# Package the helm chart
+	$(HELM) package $(CHART_DIRECTORY)
+
 # GPG_KEY_UID: substring of the desired key's uid, the name or email
 GPG_KEY_UID ?= 'Kuadrant Development Team'
-# GPG_KEYRING_BASE64: the gpg keyring base64 encoded
-GPG_KEYRING_BASE64 ?= <KUADRANT_GPG_KEYRING_BASE64>
-
-.PHONY: helm-package
-helm-package: $(HELM) ## Package the helm chart and GPG sign it
-	# Store the key
-	mkdir -p .gpg
-	echo $(GPG_KEYRING_BASE64) | base64 -d > .gpg/kuadrantsecring.gpg  #storing base64 GPG key into keyring
-	# Package the helm chart
-	$(HELM) package --sign --key $(GPG_KEY_UID) --keyring .gpg/kuadrantsecring.gpg $(CHART_DIRECTORY)
+# The keyring should've been imported before running this target
+.PHONY: helm-package-sign
+helm-package-sign: $(HELM) ## Package the helm chart and GPG sign it
+	# Package the helm chart and sign it
+	$(HELM) package --sign --key $(GPG_KEY_UID) $(CHART_DIRECTORY)
 
 # GitHub Token with permissions to upload to the release assets
 HELM_WORKFLOWS_TOKEN ?= <YOUR-TOKEN>

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -31,10 +31,18 @@ helm-upgrade: $(HELM) ## Upgrade the helm chart
 	# Upgrade the helm chart in the cluster
 	$(HELM) upgrade $(CHART_NAME) $(CHART_DIRECTORY)
 
+# GPG_KEY_UID: substring of the desired key's uid, the name or email
+GPG_KEY_UID ?= 'Kuadrant Development Team'
+# GPG_KEYRING_BASE64: the gpg keyring base64 encoded
+GPG_KEYRING_BASE64 ?= <KUADRANT_GPG_KEYRING_BASE64>
+
 .PHONY: helm-package
-helm-package: $(HELM) ## Package the helm chart
+helm-package: $(HELM) ## Package the helm chart and GPG sign it
+	# Store the key
+	mkdir -p .gpg
+	echo $(GPG_KEYRING_BASE64) | base64 -d > .gpg/kuadrantsecring.gpg  #storing base64 GPG key into keyring
 	# Package the helm chart
-	$(HELM) package $(CHART_DIRECTORY)
+	$(HELM) package --sign --key $(GPG_KEY_UID) --keyring .gpg/kuadrantsecring.gpg $(CHART_DIRECTORY)
 
 # GitHub Token with permissions to upload to the release assets
 HELM_WORKFLOWS_TOKEN ?= <YOUR-TOKEN>


### PR DESCRIPTION
Part of the work needed for https://github.com/Kuadrant/helm-charts/issues/18

This PR introduces the GPG signing of Helm chart packages upon creation. It also uploads its provenance file to the GH release page.

The job now requires to be passed an environment variable GPG_KEYRING_BASE64 which represents the GPG keyring base64 encoded, in order to be stored as a GH action variable.