### PR TITLE
Triggering builds on full semver tags

### DIFF
--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -3,7 +3,7 @@ name: Build and Publish Images For Tag Release
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-?**"
 env:
   IMG_REGISTRY_HOST: quay.io
   IMG_REGISTRY_ORG: kuadrant


### PR DESCRIPTION
This PR modifies the event listener for pushing tags following a GH action regex matching  semver with pre release and build metadata parts, like `vx.y.z-alpha1`, `vx.y.z-rc1`, `vx.y.z-dev`, etc. Previously it only matched `vx.y.z`

Following https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

Notes:

This will also match `vx.y.zwhatever`, GH actions regex is limited and we can't use a proper regex for semver like in https://semver.org/ 