### PR TITLE
do not overwrite user added labels added to the deployment template

### DIFF
--- a/controllers/limitador_controller.go
+++ b/controllers/limitador_controller.go
@@ -229,6 +229,8 @@ func (r *LimitadorReconciler) reconcileDeployment(ctx context.Context, limitador
 		reconcilers.DeploymentPortsMutator,
 		reconcilers.DeploymentLivenessProbeMutator,
 		reconcilers.DeploymentReadinessProbeMutator,
+		reconcilers.DeploymentTemplateLabelMutator,
+		reconcilers.DeploymentObjectLabelMutator,
 	)
 
 	// reconcile imagepullsecrets only when set in limitador CR

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -2,12 +2,13 @@ package helpers
 
 import (
 	"fmt"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	DeleteTagAnnotation = "limitador.kuadrant.io/delete"
+	DeleteTagAnnotation       = "limitador.kuadrant.io/delete"
+	LabelKeyApp               = "app"
+	LabelKeyLimitadorResource = "limitador-resource"
 )
 
 func ObjectInfo(obj client.Object) string {
@@ -32,4 +33,25 @@ func IsObjectTaggedToDelete(obj client.Object) bool {
 
 	annotation, ok := annotations[DeleteTagAnnotation]
 	return ok && annotation == "true"
+}
+
+func MergeMapStringString(existing *map[string]string, desired map[string]string) bool {
+	if existing == nil {
+		return false
+	}
+	if *existing == nil {
+		*existing = map[string]string{}
+	}
+
+	// for each desired key value set, e.g. labels
+	// check if it's present in existing. if not add it to existing.
+	// e.g. preserving existing labels while adding those that are in the desired set.
+	modified := false
+	for desiredKey, desiredValue := range desired {
+		if existingValue, exists := (*existing)[desiredKey]; !exists || existingValue != desiredValue {
+			(*existing)[desiredKey] = desiredValue
+			modified = true
+		}
+	}
+	return modified
 }

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -1,0 +1,89 @@
+package helpers
+
+import (
+	"testing"
+)
+
+func TestMergeMapStringString(t *testing.T) {
+	m := make(map[string]string)
+	limitadorName := "limitador"
+	type args struct {
+		existing *map[string]string
+		desired  map[string]string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantUpdate bool
+	}{
+		{
+			name: "nil pointer",
+			args: args{
+				existing: nil,
+				desired: map[string]string{
+					LabelKeyApp:               "limitador",
+					LabelKeyLimitadorResource: limitadorName,
+				},
+			},
+			wantUpdate: false,
+		},
+		{
+			name: "empty map",
+			args: args{
+				existing: &m,
+				desired: map[string]string{
+					LabelKeyApp:               "limitador",
+					LabelKeyLimitadorResource: limitadorName,
+				},
+			},
+			wantUpdate: true,
+		},
+		{
+			name: "update happened",
+			args: args{
+				existing: &map[string]string{
+					"user-added-key": "value",
+				},
+				desired: map[string]string{
+					LabelKeyApp:               "limitador",
+					LabelKeyLimitadorResource: limitadorName,
+				},
+			},
+			wantUpdate: true,
+		},
+		{
+			name: "no update happened",
+			args: args{
+				existing: &map[string]string{
+					LabelKeyApp:               "limitador",
+					LabelKeyLimitadorResource: limitadorName,
+				},
+				desired: map[string]string{
+					LabelKeyApp:               "limitador",
+					LabelKeyLimitadorResource: limitadorName,
+				},
+			},
+			wantUpdate: false,
+		}, {
+			name: "preserve hardcoded values",
+			args: args{
+				existing: &map[string]string{
+					LabelKeyApp: "blah",
+				},
+				desired: map[string]string{
+					LabelKeyApp:               "limitador",
+					LabelKeyLimitadorResource: limitadorName,
+				},
+			},
+			wantUpdate: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MergeMapStringString(tt.args.existing, tt.args.desired)
+			if got != tt.wantUpdate {
+				t.Errorf("MergeMapStringString() got = %v, wantUpdate %v", got, tt.wantUpdate)
+			}
+		})
+	}
+}

--- a/pkg/limitador/k8s_objects.go
+++ b/pkg/limitador/k8s_objects.go
@@ -2,7 +2,6 @@ package limitador
 
 import (
 	"fmt"
-
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -219,8 +218,8 @@ func ValidatePDB(pdb *policyv1.PodDisruptionBudget) error {
 
 func Labels(limitador *limitadorv1alpha1.Limitador) map[string]string {
 	return map[string]string{
-		"app":                "limitador",
-		"limitador-resource": limitador.ObjectMeta.Name,
+		helpers.LabelKeyApp:               "limitador",
+		helpers.LabelKeyLimitadorResource: limitador.ObjectMeta.Name,
 	}
 }
 

--- a/pkg/limitador/k8s_objects_test.go
+++ b/pkg/limitador/k8s_objects_test.go
@@ -90,10 +90,11 @@ func TestDeployment(t *testing.T) {
 				"app":                "limitador",
 				"limitador-resource": "some-name",
 			})
-	})
-	t.Run("selector", func(subT *testing.T) {
-		limObj := newTestLimitadorObj("some-name", "some-ns", nil)
-		deployment := Deployment(limObj, DeploymentOptions{})
+		assert.DeepEqual(subT, deployment.Spec.Template.Labels,
+			map[string]string{
+				"app":                "limitador",
+				"limitador-resource": "some-name",
+			})
 		assert.DeepEqual(subT, deployment.Spec.Selector.MatchLabels,
 			map[string]string{
 				"app":                "limitador",

--- a/pkg/reconcilers/deployment.go
+++ b/pkg/reconcilers/deployment.go
@@ -2,6 +2,7 @@ package reconcilers
 
 import (
 	"fmt"
+	"github.com/kuadrant/limitador-operator/pkg/helpers"
 	"reflect"
 
 	"github.com/google/go-cmp/cmp"
@@ -35,6 +36,14 @@ func DeploymentMutator(opts ...DeploymentMutateFn) MutateFn {
 
 		return update, nil
 	}
+}
+
+func DeploymentTemplateLabelMutator(desired, existing *appsv1.Deployment) bool {
+	return helpers.MergeMapStringString(&existing.Spec.Template.Labels, desired.Spec.Template.Labels)
+}
+
+func DeploymentObjectLabelMutator(desired, existing *appsv1.Deployment) bool {
+	return helpers.MergeMapStringString(&existing.Labels, desired.Labels)
 }
 
 func DeploymentAffinityMutator(desired, existing *appsv1.Deployment) bool {


### PR DESCRIPTION
Closes https://github.com/Kuadrant/limitador-operator/issues/176

### Verification

- Checkout locally.
- Run `make run`
- `kubectl edit deployment`
- Add label to `spec.template.labels` something like `useradded: label`
- Verify that the deployment `spec.template.labels` includes the following labels
```
app: limitador
limitador-resource: limitador-sample
useradded: label
```


