### PR TITLE
make order of desired and exsting object persistent throughout mutators

### DIFF
--- a/controllers/limitador_controller.go
+++ b/controllers/limitador_controller.go
@@ -321,7 +321,7 @@ func (r *LimitadorReconciler) reconcileLimitsConfigMap(ctx context.Context, limi
 	return nil
 }
 
-func mutateLimitsConfigMap(existingObj, desiredObj client.Object) (bool, error) {
+func mutateLimitsConfigMap(desiredObj, existingObj client.Object) (bool, error) {
 	existing, ok := existingObj.(*corev1.ConfigMap)
 	if !ok {
 		return false, fmt.Errorf("%T is not a *corev1.ConfigMap", existingObj)

--- a/pkg/reconcilers/base_reconciler.go
+++ b/pkg/reconcilers/base_reconciler.go
@@ -36,7 +36,7 @@ import (
 )
 
 // MutateFn is a function which mutates the existing object into it's desired state.
-type MutateFn func(existing, desired client.Object) (bool, error)
+type MutateFn func(desired, existing client.Object) (bool, error)
 
 func CreateOnlyMutator(_, _ client.Object) (bool, error) {
 	return false, nil
@@ -127,7 +127,7 @@ func (b *BaseReconciler) ReconcileResource(ctx context.Context, obj, desired cli
 		return b.DeleteResource(ctx, desired)
 	}
 
-	update, err := mutateFn(obj, desired)
+	update, err := mutateFn(desired, obj)
 	if err != nil {
 		return err
 	}

--- a/pkg/reconcilers/base_reconciler_test.go
+++ b/pkg/reconcilers/base_reconciler_test.go
@@ -165,7 +165,7 @@ func TestBaseReconcilerUpdateNeeded(t *testing.T) {
 		},
 	}
 
-	customMutator := func(existingObj, desiredObj client.Object) (bool, error) {
+	customMutator := func(desiredObj, existingObj client.Object) (bool, error) {
 		existing, ok := existingObj.(*v1.ConfigMap)
 		if !ok {
 			return false, fmt.Errorf("%T is not a *v1.ConfigMap", existingObj)

--- a/pkg/reconcilers/deployment.go
+++ b/pkg/reconcilers/deployment.go
@@ -15,7 +15,7 @@ import (
 type DeploymentMutateFn func(desired, existing *appsv1.Deployment) bool
 
 func DeploymentMutator(opts ...DeploymentMutateFn) MutateFn {
-	return func(existingObj, desiredObj client.Object) (bool, error) {
+	return func(desiredObj, existingObj client.Object) (bool, error) {
 		existing, ok := existingObj.(*appsv1.Deployment)
 		if !ok {
 			return false, fmt.Errorf("%T is not a *appsv1.Deployment", existingObj)

--- a/pkg/reconcilers/deployment_test.go
+++ b/pkg/reconcilers/deployment_test.go
@@ -382,7 +382,7 @@ func TestDeploymentMutator(t *testing.T) {
 		mutator := reconcilers.DeploymentMutator(
 			nameMutator, commandMutator, imageMutator,
 		)
-		updated, err := mutator(existing, &appsv1.Deployment{})
+		updated, err := mutator(&appsv1.Deployment{}, existing)
 		assert.NilError(subT, err)
 		assert.Assert(subT, updated)
 		assert.Equal(subT, existing.Spec.Template.Spec.Containers[0].Name, "newName")

--- a/pkg/reconcilers/poddisruptionbudget.go
+++ b/pkg/reconcilers/poddisruptionbudget.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func PodDisruptionBudgetMutator(existingObj, desiredObj client.Object) (bool, error) {
+func PodDisruptionBudgetMutator(desiredObj, existingObj client.Object) (bool, error) {
 	update := false
 
 	existing, ok := existingObj.(*policyv1.PodDisruptionBudget)

--- a/pkg/reconcilers/service.go
+++ b/pkg/reconcilers/service.go
@@ -12,7 +12,7 @@ import (
 type ServiceMutateFn func(desired, existing *v1.Service) bool
 
 func ServiceMutator(opts ...ServiceMutateFn) MutateFn {
-	return func(existingObj, desiredObj client.Object) (bool, error) {
+	return func(desiredObj, existingObj client.Object) (bool, error) {
 		existing, ok := existingObj.(*v1.Service)
 		if !ok {
 			return false, fmt.Errorf("%T is not a *v1.Service", existingObj)


### PR DESCRIPTION
The order in which the desired and existing objects are passed through the mutator functions should be consistent to avoid confusion when reading.