### PR TITLE
RELEASE.md: Verify OLM Deployment

### DIFF
--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -152,7 +152,7 @@ jobs:
         if: ${{ needs.build-bundle.outputs.image != steps.parsed-operator-bundle.outputs.image }}
         run: exit 1
       - name: Generate Catalog Content
-        run: make catalog
+        run: make catalog DEFAULT_CHANNEL=stable
       - name: Install qemu dependency
         run: |
           sudo apt-get update

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,37 +16,28 @@
 
 3. Verify that the build [release tag workflow](https://github.com/Kuadrant/limitador-operator/actions/workflows/build-images-for-tag-release.yaml) is triggered and completes for the new tag
 
-4. Verify the new version can be installed from the catalog image, see [Verify OLM Deployment](#verify-olm-deployment)
-
-### Verify OLM Deployment
-
-1. Deploy the OLM catalog image following the [Deploy the operator using OLM](/doc/development.md#deploy-the-operator-using-olm) and providing the generated catalog image. For example:
-```sh
-make deploy-catalog CATALOG_IMG=quay.io/kuadrant/limitador-operator-catalog:v0.13.0 DEFAULT_CHANNEL=stable
-```
-
-2. Wait for deployment:
-```sh
-kubectl -n limitador-system wait --timeout=60s --for=condition=Available deployments --all
-```
-
-The output should be:
-
-```
-deployment.apps/limitador-operator-controller-manager condition met
-```
-
-3. Check the logs:
-```sh
-kubectl -n limitador-system logs deployment/limitador-operator-controller-manager
-```
-
-4. Check the version of the components deployed:
-```sh
-kubectl -n limitador-system get deployment -o yaml | grep "image:"
-```
-The output should be something like:
-
-```
-image: quay.io/kuadrant/limitador-operator:v0.13.0
-```
+4. Verify the new version can be installed from the catalog image.
+   4.1. Deploy the OLM catalog image following the [Deploy the operator using OLM](/doc/development.md#deploy-the-operator-using-olm) and providing the generated catalog image. For example:
+   ```sh
+   make deploy-catalog CATALOG_IMG=quay.io/kuadrant/limitador-operator-catalog:v0.13.0 DEFAULT_CHANNEL=stable
+   ```
+   4.2. Wait for deployment:
+   ```sh
+   kubectl -n limitador-system wait --timeout=60s --for=condition=Available deployments --all
+   ```
+    The output should be:
+   ```
+   deployment.apps/limitador-operator-controller-manager condition met
+   ```
+   4.3. Check the logs:
+   ```sh
+   kubectl -n limitador-system logs deployment/limitador-operator-controller-manager
+   ```
+   4.4. Check the version of the components deployed:
+   ```sh
+   kubectl -n limitador-system get deployment -o yaml | grep "image:"
+   ```
+   The output should be something like:
+   ```
+   image: quay.io/kuadrant/limitador-operator:v0.13.0
+   ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,6 +17,7 @@
 3. Verify that the build [release tag workflow](https://github.com/Kuadrant/limitador-operator/actions/workflows/build-images-for-tag-release.yaml) is triggered and completes for the new tag
 
 4. Verify the new version can be installed from the catalog image.
+
    4.1. Deploy the new OLM catalog image
    Create kind cluster
    ```sh

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,13 +18,11 @@
 
 4. Verify the new version can be installed from the catalog image, see [Verify OLM Deployment](#verify-olm-deployment)
 
-5. Release to the [community operator index catalogs](#community-operator-index-catalogs).
-
 ### Verify OLM Deployment
 
 1. Deploy the OLM catalog image following the [Deploy the operator using OLM](/doc/development.md#deploy-the-operator-using-olm) and providing the generated catalog image. For example:
 ```sh
-make deploy-catalog CATALOG_IMG=quay.io/kuadrant/limitador-operator-catalog:v0.13.0
+make deploy-catalog CATALOG_IMG=quay.io/kuadrant/limitador-operator-catalog:v0.13.0 DEFAULT_CHANNEL=stable
 ```
 
 2. Wait for deployment:
@@ -40,7 +38,7 @@ deployment.apps/limitador-operator-controller-manager condition met
 
 3. Check the logs:
 ```sh
-kubectl -n limitador-system logs -f deployment/limitador-operator-controller-manager
+kubectl -n limitador-system logs deployment/limitador-operator-controller-manager
 ```
 
 4. Check the version of the components deployed:
@@ -52,21 +50,3 @@ The output should be something like:
 ```
 image: quay.io/kuadrant/limitador-operator:v0.13.0
 ```
-
-### Community Operator Index Catalogs
-
-- [Operatorhub Community Operators](https://github.com/k8s-operatorhub/community-operators)
-- [Openshift Community Operators](http://github.com/redhat-openshift-ecosystem/community-operators-prod)
-
-Open a PR on each index catalog ([example](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/1595) |
-[docs](https://redhat-openshift-ecosystem.github.io/community-operators-prod/operator-release-process/)).
-
-The usual steps are:
-
-1. Start a new branch named `limitador-operator-v0.W.Z`
-
-2. Create a new directory `operators/limitador-operator/0.W.Z` containing:
-
-    * Copy the bundle files from `github.com/kuadrant/limitador-operator/tree/v0.W.Z/bundle`
-    * Copy `github.com/kuadrant/limitador-operator/tree/v0.W.Z/bundle.Dockerfile` with the proper fix to the COPY commands
-      (i.e. remove /bundle from the paths)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,9 +17,18 @@
 3. Verify that the build [release tag workflow](https://github.com/Kuadrant/limitador-operator/actions/workflows/build-images-for-tag-release.yaml) is triggered and completes for the new tag
 
 4. Verify the new version can be installed from the catalog image.
-   4.1. Deploy the OLM catalog image following the [Deploy the operator using OLM](/doc/development.md#deploy-the-operator-using-olm) and providing the generated catalog image. For example:
+   4.1. Deploy the new OLM catalog image
+   Create kind cluster
    ```sh
-   make deploy-catalog CATALOG_IMG=quay.io/kuadrant/limitador-operator-catalog:v0.13.0 DEFAULT_CHANNEL=stable
+   make kind-create-cluster
+   ```
+   Deploy OLM system
+   ```sh
+   make install-olm
+   ```
+   Deploy the catalog image. Replace `<NEW_TAG>` with the new release tag.
+   ```sh
+   make deploy-catalog CATALOG_IMG=quay.io/kuadrant/limitador-operator-catalog:<NEW_TAG> DEFAULT_CHANNEL=stable
    ```
    4.2. Wait for deployment:
    ```sh

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,11 +14,44 @@
     * Limitador version the operator enables installations of (without prefix) – i.e. `0.X.Y`
     * If the release is a prerelease
 
-3. Verify that the build [release tag workflow](https://github.com/Kuadrant/dns-operator/actions/workflows/build-images-for-tag-release.yaml) is triggered and completes for the new tag
+3. Verify that the build [release tag workflow](https://github.com/Kuadrant/limitador-operator/actions/workflows/build-images-for-tag-release.yaml) is triggered and completes for the new tag
 
 4. Verify the new version can be installed from the catalog image, see [Verify OLM Deployment](#verify-olm-deployment)
 
 5. Release to the [community operator index catalogs](#community-operator-index-catalogs).
+
+### Verify OLM Deployment
+
+1. Deploy the OLM catalog image following the [Deploy the operator using OLM](/doc/development.md#deploy-the-operator-using-olm) and providing the generated catalog image. For example:
+```sh
+make deploy-catalog CATALOG_IMG=quay.io/kuadrant/limitador-operator-catalog:v0.13.0
+```
+
+2. Wait for deployment:
+```sh
+kubectl -n limitador-system wait --timeout=60s --for=condition=Available deployments --all
+```
+
+The output should be:
+
+```
+deployment.apps/limitador-operator-controller-manager condition met
+```
+
+3. Check the logs:
+```sh
+kubectl -n limitador-system logs -f deployment/limitador-operator-controller-manager
+```
+
+4. Check the version of the components deployed:
+```sh
+kubectl -n limitador-system get deployment -o yaml | grep "image:"
+```
+The output should be something like:
+
+```
+image: quay.io/kuadrant/limitador-operator:v0.13.0
+```
 
 ### Community Operator Index Catalogs
 

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -40,7 +40,7 @@ catalog: $(OPM) ## Generate catalog content and validate.
 	# Initializing the Catalog
 	-rm -rf $(PROJECT_PATH)/catalog/limitador-operator-catalog
 	-rm -rf $(PROJECT_PATH)/catalog/limitador-operator-catalog.Dockerfile
-	$(MAKE) $(CATALOG_DOCKERFILE)
+	$(MAKE) $(CATALOG_DOCKERFILE) DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
 	$(MAKE) $(CATALOG_FILE) BUNDLE_IMG=$(BUNDLE_IMG)
 	cd $(PROJECT_PATH)/catalog && $(OPM) validate limitador-operator-catalog
 

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -58,6 +58,7 @@ catalog-push: ## Push a catalog image.
 
 deploy-catalog: $(KUSTOMIZE) $(YQ) ## Deploy operator to the K8s cluster specified in ~/.kube/config using OLM catalog image.
 	V="$(CATALOG_IMG)" $(YQ) eval '.spec.image = strenv(V)' -i config/deploy/olm/catalogsource.yaml
+	V="$(DEFAULT_CHANNEL)" $(YQ) eval '.spec.channel = strenv(V)' -i config/deploy/olm/subscription.yaml
 	$(KUSTOMIZE) build config/deploy/olm | kubectl apply -f -
 
 undeploy-catalog: $(KUSTOMIZE) ## Undeploy controller from the K8s cluster specified in ~/.kube/config using OLM catalog image.


### PR DESCRIPTION
Fixes #187 

Additionally: Fix channel used for custom catalogs. Aligned with the kuadrant operator: using `preview` for nightly/latest custom catalogs and `stable` for tagged releases.