### PR TITLE
Go1.23 🚀

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -111,10 +111,10 @@ jobs:
     name: Build Bundle
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.22.x
+      - name: Set up Go 1.23.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
         id: go
       - name: Check out code
         uses: actions/checkout@v3
@@ -167,10 +167,10 @@ jobs:
     needs: [build, build-bundle]
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.22.x
+      - name: Set up Go 1.23.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
         id: go
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,10 +28,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gettext-base
-      - name: Set up Go 1.22.x
+      - name: Set up Go 1.23.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
         id: go
       - name: Checkout code at git ref
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,10 +37,10 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: Set up Go 1.22.x
+      - name: Set up Go 1.23.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
         id: go
       - uses: actions/checkout@v4
       - name: Run make test-unit
@@ -62,10 +62,10 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: Set up Go 1.22.x
+      - name: Set up Go 1.23.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
         id: go
       - name: Check out code
         uses: actions/checkout@v4
@@ -95,10 +95,10 @@ jobs:
     needs: pre-job
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.22.x
+      - name: Set up Go 1.23.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
         id: go
       - uses: actions/checkout@v4
       - name: Verify manifests
@@ -109,10 +109,10 @@ jobs:
     needs: pre-job
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.22.x
+      - name: Set up Go 1.23.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
         id: go
       - name: Check out code
         uses: actions/checkout@v4
@@ -125,10 +125,10 @@ jobs:
     needs: pre-job
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.22.x
+      - name: Set up Go 1.23.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
         id: go
       - name: Check out code
         uses: actions/checkout@v4
@@ -141,10 +141,10 @@ jobs:
     needs: pre-job
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.22.x
+      - name: Set up Go 1.23.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
         id: go
       - name: Check out code
         uses: actions/checkout@v4
@@ -160,10 +160,10 @@ jobs:
     needs: pre-job
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.22.x
+      - name: Set up Go 1.23.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
         id: go
       - name: Check out code
         uses: actions/checkout@v4
@@ -175,10 +175,10 @@ jobs:
     needs: pre-job
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.22.x
+      - name: Set up Go 1.23.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
         id: go
       - name: Check out code
         uses: actions/checkout@v4
@@ -191,10 +191,10 @@ jobs:
     needs: pre-job
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.22.x
+      - name: Set up Go 1.23.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
         id: go
       - name: Check out code
         uses: actions/checkout@v4
@@ -207,10 +207,10 @@ jobs:
     needs: pre-job
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.22.x
+      - name: Set up Go 1.23.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
         id: go
       - name: Check out code
         uses: actions/checkout@v4

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,3 +25,11 @@ issues:
     - text: "var-naming: don't use leading k in Go names"
       linters:
         - revive
+
+linters-settings:
+  revive:
+    ignore-generated-header: true
+    severity: warning
+    rules:
+      - name: dot-imports
+        arguments: [{"allowedPackages": ["github.com/onsi/ginkgo/v2", "github.com/onsi/gomega"]}]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM mirror.gcr.io/library/golang:1.22 AS builder
+FROM mirror.gcr.io/library/golang:1.23 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ act: $(ACT) ## Download act locally if necessary.
 
 GOLANGCI-LINT = $(PROJECT_PATH)/bin/golangci-lint
 $(GOLANGCI-LINT):
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(PROJECT_PATH)/bin v1.54.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(PROJECT_PATH)/bin v1.64.8
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI-LINT) ## Download golangci-lint locally if necessary.

--- a/api/v1alpha1/limitador_types.go
+++ b/api/v1alpha1/limitador_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"math"
 	"reflect"
 
 	"github.com/go-logr/logr"
@@ -169,7 +170,17 @@ func (l *Limitador) GetReplicas() int32 {
 		return DefaultReplicas
 	}
 
-	return int32(*l.Spec.Replicas)
+	replicas := *l.Spec.Replicas
+
+	if replicas > math.MaxInt32 {
+		return math.MaxInt32
+	}
+
+	if replicas < math.MinInt32 {
+		return math.MinInt32
+	}
+
+	return int32(replicas)
 }
 
 //+kubebuilder:object:root=true

--- a/doc/development.md
+++ b/doc/development.md
@@ -5,7 +5,7 @@
 * [operator-sdk] version 1.32.0
 * [kind] version v0.22.0
 * [git][git_tool]
-* [go] version 1.22+
+* [go] version 1.23+
 * [kubernetes] version v1.25+
 * [kubectl] version v1.25+
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/limitador-operator
 
-go 1.22.5
+go 1.23.6
 
 require (
 	github.com/go-logr/logr v1.3.0

--- a/pkg/reconcilers/base_reconciler_test.go
+++ b/pkg/reconcilers/base_reconciler_test.go
@@ -165,7 +165,7 @@ func TestBaseReconcilerUpdateNeeded(t *testing.T) {
 		},
 	}
 
-	customMutator := func(desiredObj, existingObj client.Object) (bool, error) {
+	customMutator := func(_, existingObj client.Object) (bool, error) {
 		existing, ok := existingObj.(*v1.ConfigMap)
 		if !ok {
 			return false, fmt.Errorf("%T is not a *v1.ConfigMap", existingObj)


### PR DESCRIPTION
### What

* Go v1.23 🚀
* golangci-lint upgraded to v1.64.8 and fixed lint issues