### PR TITLE
UPDATE: CRD validation

### DIFF
--- a/api/v1alpha1/limitador_types.go
+++ b/api/v1alpha1/limitador_types.go
@@ -349,6 +349,7 @@ type Tracing struct {
 	Endpoint string `json:"endpoint"`
 }
 
+// +kubebuilder:validation:XValidation:rule="!(has(self.maxUnavailable) && has(self.minAvailable))",message="pdb spec invalid, maxUnavailable and minAvailable are mutually exclusive"
 type PodDisruptionBudgetType struct {
 	// An eviction is allowed if at most "maxUnavailable" limitador pods
 	// are unavailable after the eviction, i.e. even in absence of

--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/limitador-operator:latest
-    createdAt: "2024-10-18T10:24:00Z"
+    createdAt: "2025-05-02T14:33:12Z"
     description: The Limitador operator installs and maintains limitador instances
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/limitador.kuadrant.io_limitadors.yaml
+++ b/bundle/manifests/limitador.kuadrant.io_limitadors.yaml
@@ -893,6 +893,10 @@ spec:
                       evictions by specifying "100%".
                     x-kubernetes-int-or-string: true
                 type: object
+                x-kubernetes-validations:
+                - message: pdb spec invalid, maxUnavailable and minAvailable are mutually
+                    exclusive
+                  rule: '!(has(self.maxUnavailable) && has(self.minAvailable))'
               rateLimitHeaders:
                 description: RateLimitHeadersType defines the valid options for the
                   --rate-limit-headers arg

--- a/charts/limitador-operator/templates/manifests.yaml
+++ b/charts/limitador-operator/templates/manifests.yaml
@@ -894,6 +894,10 @@ spec:
                       evictions by specifying "100%".
                     x-kubernetes-int-or-string: true
                 type: object
+                x-kubernetes-validations:
+                - message: pdb spec invalid, maxUnavailable and minAvailable are mutually
+                    exclusive
+                  rule: '!(has(self.maxUnavailable) && has(self.minAvailable))'
               rateLimitHeaders:
                 description: RateLimitHeadersType defines the valid options for the
                   --rate-limit-headers arg

--- a/config/crd/bases/limitador.kuadrant.io_limitadors.yaml
+++ b/config/crd/bases/limitador.kuadrant.io_limitadors.yaml
@@ -893,6 +893,10 @@ spec:
                       evictions by specifying "100%".
                     x-kubernetes-int-or-string: true
                 type: object
+                x-kubernetes-validations:
+                - message: pdb spec invalid, maxUnavailable and minAvailable are mutually
+                    exclusive
+                  rule: '!(has(self.maxUnavailable) && has(self.minAvailable))'
               rateLimitHeaders:
                 description: RateLimitHeadersType defines the valid options for the
                   --rate-limit-headers arg

--- a/controllers/limitador_controller.go
+++ b/controllers/limitador_controller.go
@@ -185,9 +185,6 @@ func (r *LimitadorReconciler) reconcilePdb(ctx context.Context, limitadorObj *li
 	}
 
 	pdb := limitador.PodDisruptionBudget(limitadorObj)
-	if err := limitador.ValidatePDB(pdb); err != nil {
-		return err
-	}
 
 	// controller reference
 	if err := r.SetOwnerReference(limitadorObj, pdb); err != nil {

--- a/controllers/limitador_controller_pdb_test.go
+++ b/controllers/limitador_controller_pdb_test.go
@@ -30,6 +30,19 @@ var _ = Describe("Limitador controller manages PodDisruptionBudget", func() {
 		DeleteNamespaceWithContext(ctx, &testNamespace)
 	}, nodeTimeOut)
 
+	Context("CEL validation on pdb configuration", func() {
+		It("Should not allow the user apply misconfigured resource", func(ctx SpecContext) {
+			limitadorObj := basicLimitador(testNamespace)
+			limitadorObj.Spec.PodDisruptionBudget = &limitadorv1alpha1.PodDisruptionBudgetType{
+				MaxUnavailable: &intstr.IntOrString{IntVal: 1},
+				MinAvailable:   &intstr.IntOrString{IntVal: 1},
+			}
+			err := k8sClient.Create(ctx, limitadorObj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("pdb spec invalid, maxUnavailable and minAvailable are mutually exclusive"))
+		})
+	})
+
 	Context("Creating a new Limitador object with specific pdb", func() {
 		var limitadorObj *limitadorv1alpha1.Limitador
 

--- a/pkg/limitador/k8s_objects.go
+++ b/pkg/limitador/k8s_objects.go
@@ -2,6 +2,7 @@ package limitador
 
 import (
 	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -207,13 +208,6 @@ func PodDisruptionBudget(limitadorObj *limitadorv1alpha1.Limitador) *policyv1.Po
 
 func PodDisruptionBudgetName(limitadorObj *limitadorv1alpha1.Limitador) string {
 	return fmt.Sprintf("limitador-%s", limitadorObj.Name)
-}
-
-func ValidatePDB(pdb *policyv1.PodDisruptionBudget) error {
-	if pdb.Spec.MaxUnavailable != nil && pdb.Spec.MinAvailable != nil {
-		return fmt.Errorf("pdb spec invalid, maxunavailable and minavailable are mutually exclusive")
-	}
-	return nil
 }
 
 func Labels(limitador *limitadorv1alpha1.Limitador) map[string]string {

--- a/pkg/limitador/k8s_objects_test.go
+++ b/pkg/limitador/k8s_objects_test.go
@@ -5,7 +5,6 @@ import (
 
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -209,17 +208,6 @@ func TestDeployment(t *testing.T) {
 func TestPodDisruptionBudgetName(t *testing.T) {
 	name := PodDisruptionBudgetName(newTestLimitadorObj("my-limitador-instance", "default", nil))
 	assert.Equal(t, name, "limitador-my-limitador-instance")
-}
-
-func TestValidatePdb(t *testing.T) {
-	limitadorPdb := &policyv1.PodDisruptionBudget{
-		Spec: policyv1.PodDisruptionBudgetSpec{
-			MaxUnavailable: intStrOne,
-			MinAvailable:   intStrOne,
-		},
-	}
-	err := ValidatePDB(limitadorPdb)
-	assert.Error(t, err, "pdb spec invalid, maxunavailable and minavailable are mutually exclusive")
 }
 
 func TestPodDisruptionBudget(t *testing.T) {


### PR DESCRIPTION

Added CEL validation for the pod disruption budget to the CRD definition. 
This gives the user faster feedback on poorly configured CRs, and the API will not allow the adding of the configuration.

Downside, the unit test needed to be replaced with an integration test. 