### PR TITLE
:fire: Remove goarch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV GIT_SHA=${GIT_SHA:-unknown}
 ENV DIRTY=${DIRTY:-unknown}
 ENV VERSION=${VERSION:-unknown}
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags "-X main.version=${VERSION} -X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-X main.version=${VERSION} -X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
I ran into issues on a Kuadrant operator install for another component - details here: https://github.com/kagenti/mcp-gateway/issues/199. The limitadaor-operator install seems to come through the helm install of the kuadrant operator here: https://github.com/kagenti/mcp-gateway/blob/main/build/kuadrant.mk#L10

The errors suggested that despite my arm machine, an amd64 image was getting pulled. This was not resolved by separately pulling images via `docker pull --platform linux/arm64...`

```
runtime: lfstack.push invalid packing: node=0xffff5db7e800 cnt=0x1 packed=0xffff5db7e8000001 -> node=0xffffffff5db7e800
fatal error: lfstack.push
...
runtime.systemstack(0x47adff)
	/usr/local/go/src/runtime/asm_amd64.s:509 +0x4a fp=0xffffa528f328 sp=0xffffa528f318 pc=0x4765ca
```
At this time, this seems most reproducible on Mac M1 machines.


It appears that there is an attempt to build images for multi-architecture here: https://github.com/Kuadrant/limitador-operator/blob/main/.github/workflows/build-images-base.yaml#L88

However, the `GOARCH` in the Dockerfile is hardcoded to `GOARCH=amd64` - removing this should allow for default building on the architecture available