### PR TITLE
fixup: use full SHA for image tag

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -85,7 +85,7 @@ jobs:
           images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}
           tags: |
             type=raw,value=${{ env.IMG_TAGS }}
-            type=sha,enable={{is_default_branch}}
+            type=raw,value=${{ github.sha }},enable={{is_default_branch}}
       - name: Build and Push Image
         id: build-image
         uses: docker/build-push-action@v5
@@ -144,7 +144,7 @@ jobs:
           images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-bundle
           tags: |
             type=raw,value=${{ env.IMG_TAGS }}
-            type=sha,enable={{is_default_branch}}
+            type=raw,value=${{ github.sha }},enable={{is_default_branch}}
       - name: Build and Push Bundle Image
         id: build-bundle-image
         uses: docker/build-push-action@v5
@@ -195,7 +195,7 @@ jobs:
           images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-catalog
           tags: |
             type=raw,value=${{ env.IMG_TAGS }}
-            type=sha,enable={{is_default_branch}}
+            type=raw,value=${{ github.sha }},enable={{is_default_branch}}
       - name: Build and Push Catalog Image
         id: build-catalog-image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
# Description
https://github.com/Kuadrant/limitador-operator/pull/210 changed the behaviour of the naming of SHA images tags to a shortened value.
- https://quay.io/repository/kuadrant/limitador-operator?tab=tags&tag=latest
<img width="1052" height="149" alt="image" src="https://github.com/user-attachments/assets/096717e3-5f2e-426d-af87-f568ad062116" />

This PR restores the original behaviour of using the full SHA as the image tag