### PR TITLE
makefile: refactor dependency tooling install

### DIFF
--- a/make/helm.mk
+++ b/make/helm.mk
@@ -6,7 +6,7 @@ CHART_NAME ?= limitador-operator
 CHART_DIRECTORY ?= charts/$(CHART_NAME)
 
 .PHONY: helm-build
-helm-build: $(KUSTOMIZE) $(OPERATOR_SDK) $(YQ) manifests ## Build the helm chart from kustomize manifests
+helm-build: kustomize operator-sdk yq manifests ## Build the helm chart from kustomize manifests
 	# Set desired operator image and related limitador image
 	V="$(RELATED_IMAGE_LIMITADOR)" $(YQ) eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_LIMITADOR").value) = strenv(V)' -i config/manager/manager.yaml
 	# Replace the controller image
@@ -17,22 +17,22 @@ helm-build: $(KUSTOMIZE) $(OPERATOR_SDK) $(YQ) manifests ## Build the helm chart
 	V="$(VERSION)" $(YQ) eval '.appVersion = strenv(V)' -i $(CHART_DIRECTORY)/Chart.yaml
 
 .PHONY: helm-install
-helm-install: $(HELM) ## Install the helm chart
+helm-install: helm ## Install the helm chart
 	# Install the helm chart in the cluster
 	$(HELM) install $(CHART_NAME) $(CHART_DIRECTORY)
 
 .PHONY: helm-uninstall
-helm-uninstall: $(HELM) ## Uninstall the helm chart
+helm-uninstall: helm ## Uninstall the helm chart
 	# Uninstall the helm chart from the cluster
 	$(HELM) uninstall $(CHART_NAME)
 
 .PHONY: helm-upgrade
-helm-upgrade: $(HELM) ## Upgrade the helm chart
+helm-upgrade: helm ## Upgrade the helm chart
 	# Upgrade the helm chart in the cluster
 	$(HELM) upgrade $(CHART_NAME) $(CHART_DIRECTORY)
 
 .PHONY: helm-package
-helm-package: $(HELM) ## Package the helm chart
+helm-package: helm ## Package the helm chart
 	# Package the helm chart
 	$(HELM) package $(CHART_DIRECTORY)
 
@@ -40,7 +40,7 @@ helm-package: $(HELM) ## Package the helm chart
 GPG_KEY_UID ?= 'Kuadrant Development Team'
 # The keyring should've been imported before running this target
 .PHONY: helm-package-sign
-helm-package-sign: $(HELM) ## Package the helm chart and GPG sign it
+helm-package-sign: helm ## Package the helm chart and GPG sign it
 	# Package the helm chart and sign it
 	$(HELM) package --sign --key "$(GPG_KEY_UID)" $(CHART_DIRECTORY)
 


### PR DESCRIPTION
# Description
* Refactor makefile dependency tools using [Kubebuilder v4 project makefile as template](https://github.com/kubernetes-sigs/kubebuilder/blob/012e741d07a34da23451b9d0c946f89dddd43609/testdata/project-v4/Makefile#L168-L232)
* Bind tool version to "X-V_BINARY" that will be checked instead by `make`. This will ensure that should the version of the tool is changed/updated, `make` will download this new version and update the symlink