### PR TITLE
Upgrade Go to 1.25.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/limitador-operator
 
-go 1.25.5
+go 1.25.8
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Summary

Upgrades Go from 1.25.5 to 1.25.8, fixing the following CVEs:

| CVE | Package | Fixed in |
|-----|---------|----------|
| CVE-2026-25679 | `net/url` | 1.25.8 |
| CVE-2026-27142 | `html/template` | 1.25.8 |
| CVE-2026-27139 | `os` | 1.25.8 |
| CVE-2025-68121 | `crypto/tls` | 1.25.7 |
| CVE-2025-61726 | `net/url` | 1.25.6 |

Part of the Go 1.25.8 upgrade across all repos (see Kuadrant/kuadrant-operator#1829).