### PR TITLE
Update nightly quay image expiry 1w->2w

### DIFF
--- a/.github/workflows/build-images-nightly.yaml
+++ b/.github/workflows/build-images-nightly.yaml
@@ -37,5 +37,5 @@ jobs:
     with:
       operatorVersion: 0.0.0
       operatorTag: ${{ needs.release-date.outputs.release_date }}
-      quayImageExpiry: 1w
+      quayImageExpiry: 2w
       relatedImageLimitador: quay.io/kuadrant/limitador@${{ needs.limitador-latest-digest.outputs.limitador_digest }}


### PR DESCRIPTION
Update nightly Quay image expiry from 1 week to 2 weeks, aligning with the [expiry interval used by kuadrant-operator nightly images](https://github.com/Kuadrant/kuadrant-operator/blob/4f48710cf3da4f96d23e58b421b2f15c9e66e64e/.github/workflows/build-images-nightly.yaml#L101-L102).

