### PR TITLE
Adopt RFC 0018 release branch naming (release-X.Y)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,10 +38,15 @@ jobs:
         with:
           go-version-file: go.mod
         id: go
-      - name: Create release branch
-        if: ${{ !startsWith(inputs.gitRef, 'release-v') }}
+      - name: Derive release branch name
+        id: release-branch
         run: |
-          git checkout -b release-v${{ inputs.limitadorOperatorVersion }}
+          release_branch=release-$(echo "${{ inputs.limitadorOperatorVersion }}" | sed 's/[+-].*//; s/\.[0-9]*$//')
+          echo "name=$release_branch" >> $GITHUB_OUTPUT
+      - name: Create release branch
+        if: ${{ !startsWith(inputs.gitRef, 'release-') }}
+        run: |
+          git checkout -b ${{ steps.release-branch.outputs.name }}
       - name: Prepare release
         run: |
           make prepare-release \
@@ -53,7 +58,7 @@ jobs:
           commit_message: "Prepared release v${{ inputs.limitadorOperatorVersion }}"
           commit_user_name: "github-actions[bot]"
           commit_user_email: "github-actions[bot]@users.noreply.github.com"
-          branch: release-v${{ inputs.limitadorOperatorVersion }}
+          branch: ${{ steps.release-branch.outputs.name }}
           create_branch: true
           tagging_message: v${{ inputs.limitadorOperatorVersion }}
           commit_options: '--signoff'
@@ -64,6 +69,6 @@ jobs:
           tag_name: v${{ inputs.limitadorOperatorVersion }}
           body: "**This release enables installations of Limitador v${{ inputs.limitadorVersion }}**"
           generate_release_notes: true
-          target_commitish: release-v${{ inputs.limitadorOperatorVersion }}
+          target_commitish: ${{ steps.release-branch.outputs.name }}
           prerelease: ${{ inputs.prerelease }}
           token: ${{ secrets.KUADRANT_DEV_PAT }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,14 @@ jobs:
       - name: Derive release branch name
         id: release-branch
         run: |
-          release_branch=release-$(echo "${{ inputs.limitadorOperatorVersion }}" | sed 's/[+-].*//; s/\.[0-9]*$//')
+          version="${{ inputs.limitadorOperatorVersion }}"
+          if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([+-].*)?$'; then
+            echo "Error: version must be semver format (e.g., 0.17.1, 0.18.0-rc1)"
+            exit 1
+          fi
+          # Extract major.minor from version (e.g., 0.17.1 → 0.17)
+          # Removes: pre-release suffix ([+-].*) and patch version (\.[0-9]*$)
+          release_branch=release-$(echo "$version" | sed 's/[+-].*//; s/\.[0-9]*$//')
           echo "name=$release_branch" >> $GITHUB_OUTPUT
       - name: Create release branch
         if: ${{ !startsWith(inputs.gitRef, 'release-') }}


### PR DESCRIPTION
## Summary

Updates the release workflow to use minor-level branch naming without `v` prefix per [RFC 0018](https://github.com/Kuadrant/architecture/blob/main/rfcs/0018-release-branch-naming.md).

## Changes

Same granularity change as Kuadrant/authorino-operator#308: one branch per minor (`release-0.17`) instead of one per patch (`release-v0.17.1`).

- Add `Derive release branch name` step computing `release-X.Y` from version input
- Change `startsWith` check from `release-v` to `release-`
- Use derived branch name for `stefanzweifel/git-auto-commit-action` branch and `target_commitish`

Part of Kuadrant/kuadrant-operator#1981

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to refine internal release process handling and branch management.

---

**Note:** This release contains internal infrastructure improvements with no direct user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/limitador-operator/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->