### PR TITLE
ci: trigger test workflow on release branch pushes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [ 'main' ]
+    branches: [ 'main', 'release-*' ]
 
   pull_request:
     branches: [ '*' ]


### PR DESCRIPTION
## Summary

Adds `release-*` to the push branch trigger in `test.yaml` so CI runs when commits land on release branches (e.g., merged backport PRs). The pull_request trigger already uses a wildcard.

Part of the RFC 0018 migration (Kuadrant/kuadrant-operator#1981).

🤖 Generated with [Claude Code](https://claude.com/claude-code)