### PR TITLE
Fix release branch CI: include release.mk before version conditionals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ SHELL = /usr/bin/env bash -o pipefail
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 
+# Load release defaults early so version-dependent conditionals (e.g. LIMITADOR_VERSION)
+# evaluate correctly. The full include at the bottom of this file is kept for other .mk files.
+-include $(PROJECT_PATH)/make/release.mk
+
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):


### PR DESCRIPTION
## Summary

Fixes `verify-bundle` and `verify-helm-charts` failures on release branches (e.g. [release-0.18 CI run](https://github.com/Kuadrant/limitador-operator/actions/runs/26590505730)).

## Root cause

The `ifeq`/`ifdef` conditionals on lines 59-65 that decide whether to prepend `v` to the limitador image tag are evaluated at **Makefile parse time**. `release.mk` (which sets `LIMITADOR_VERSION=2.4.0`) was included at line 444 — after these conditionals had already evaluated against the default value `latest`.

Since `latest` doesn't match the semver regex, the `else` branch was taken, producing `limitador:2.4.0` instead of `limitador:v2.4.0`. The committed CSV (generated by `make prepare-release`, which passes the version on the command line) correctly has `v2.4.0`, causing the verification diff to fail.

## Fix

Add an early `-include` of `release.mk` after `MKFILE_PATH`/`PROJECT_PATH` are set (line 8), before any version-dependent conditionals. The `-include` (with dash prefix) silently skips when the file doesn't exist (e.g. on `main` where there is no `release.mk`). The full `include ./make/*.mk` at the bottom is kept for the other `.mk` files.

## Verified locally

```
$ git checkout origin/release-0.18
$ # Apply the fix
$ make bundle
$ git diff bundle/
# No diff — bundle regenerates cleanly
$ make helm-build
$ git diff charts/
# No diff — helm charts regenerate cleanly
```

Without the fix, `make bundle` produces a diff changing `limitador:v2.4.0` → `limitador:2.4.0` in two places in the CSV.

## Note

This fix needs to be **cherry-picked to `release-0.18`** to unblock CI on that branch.

## Test plan
- [ ] CI passes on this PR (main branch — no `release.mk` exists, `-include` skips silently)
- [ ] Cherry-pick to `release-0.18` and verify CI passes there

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build system configuration to enhance release management workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/limitador-operator/pull/257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->