### PR TITLE
Backport: Fix release branch CI (release.mk include order)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ SHELL = /usr/bin/env bash -o pipefail
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 
+# Load release defaults early so version-dependent conditionals (e.g. LIMITADOR_VERSION)
+# evaluate correctly. The full include at the bottom of this file is kept for other .mk files.
+-include $(PROJECT_PATH)/make/release.mk
+
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):


### PR DESCRIPTION
## Summary

Cherry-pick of #257 to `release-0.18` to fix the `verify-bundle` and `verify-helm-charts` CI failures ([run 26590505730](https://github.com/Kuadrant/limitador-operator/actions/runs/26590505730)).

The `ifeq` conditionals that prepend `v` to the limitador image tag evaluated before `release.mk` was included, producing `limitador:2.4.0` instead of `limitador:v2.4.0`.

See #257 for full details.

## Test plan
- [ ] CI passes on `release-0.18` — `verify-bundle` and `verify-helm-charts` should now succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)