### PR TITLE
Upgrade Go to 1.26.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Limitador Operator is a Kubernetes operator that manages [Limitador](https://git
 Limitador is a rate-limiting service. The operator reconciles `Limitador` custom resources (CRD) to create and manage
 deployments, services, ConfigMaps, PVCs, and PodDisruptionBudgets in Kubernetes.
 
-**Built with:** Kubebuilder v3, operator-sdk v1.32.0, Go 1.25+
+**Built with:** Kubebuilder v3, operator-sdk v1.32.0, Go 1.26+
 
 ## Common Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Limitador Operator is a Kubernetes operator that manages [Limitador](https://git
 Limitador is a rate-limiting service. The operator reconciles `Limitador` custom resources (CRD) to create and manage
 deployments, services, ConfigMaps, PVCs, and PodDisruptionBudgets in Kubernetes.
 
-**Built with:** Kubebuilder v3, operator-sdk v1.32.0, Go 1.26+
+**Built with:** Kubebuilder v3, operator-sdk v1.32.0, Go (see `go.mod`)
 
 ## Common Commands
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM mirror.gcr.io/library/golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM mirror.gcr.io/library/golang:1.26 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/limitador-operator
 
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/limitador-operator
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
Upgrade Go from 1.25.9 to 1.26.3.

**Changes:**
- `go.mod`: `go 1.25.9` → `go 1.26.3`
- `Dockerfile`: `mirror.gcr.io/library/golang:1.25` → `mirror.gcr.io/library/golang:1.26`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version from 1.25 to 1.26 in project documentation, Docker build configuration, and Go module settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->