### PR TITLE
Set olm channels and default_channel to stable on release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,6 +58,8 @@ jobs:
         run: |
           make prepare-release \
           VERSION=${{ inputs.limitadorOperatorVersion }} \
+          CHANNELS=stable \
+          DEFAULT_CHANNEL=stable \
           LIMITADOR_VERSION=${{ inputs.limitadorVersion }}
       - name: Commit and push
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/Makefile
+++ b/Makefile
@@ -415,6 +415,8 @@ prepare-release: ## Prepare the manifests for OLM and Helm Chart for a release.
 		'CATALOG_IMG?=$(IMAGE_TAG_BASE)-catalog:$$(IMAGE_TAG)' \
 		'CHANNELS?=$(CHANNELS)' \
 		'BUNDLE_CHANNELS?=--channels=$(CHANNELS)' \
+		'DEFAULT_CHANNEL?=$(DEFAULT_CHANNEL)' \
+		'BUNDLE_DEFAULT_CHANNEL?=--default-channel=$(DEFAULT_CHANNEL)' \
 		'VERSION?=$(VERSION)' \
 		> $(RELEASE_FILE)
 	$(MAKE) bundle VERSION=$(VERSION) LIMITADOR_VERSION=$(LIMITADOR_VERSION)


### PR DESCRIPTION
## What

Sets the OLM channels and default channel to `stable` when the release workflow runs, and fixes the `prepare-release` Makefile target to persist `DEFAULT_CHANNEL`/`BUNDLE_DEFAULT_CHANNEL` into the generated `make/release.mk`.

## Why

`prepare-release` already persisted `CHANNELS`/`BUNDLE_CHANNELS` into `make/release.mk`, but never did the same for `DEFAULT_CHANNEL`/`BUNDLE_DEFAULT_CHANNEL`. That meant any subsequent `make bundle` or `make helm-build` invocation silently fell back to the Makefile default (`alpha`) for the default channel, even when `CHANNELS=stable` was set for the release. This caused a mismatch on the `release-0.18` branch, whose bundle ended up advertising `channels: stable` but `default-channel: alpha` (see #268, which repaired that branch after the fact).

This PR fixes the root cause on `main` so future releases don't hit the same issue:

- `.github/workflows/release.yaml`: passes `CHANNELS=stable` and `DEFAULT_CHANNEL=stable` explicitly to `make prepare-release`.
- `Makefile`: `prepare-release` now also writes `DEFAULT_CHANNEL` and `BUNDLE_DEFAULT_CHANNEL` to `make/release.mk`, mirroring the existing `CHANNELS`/`BUNDLE_CHANNELS` entries.

## Related

- #268 — fixed the same class of bug on the already-released `release-0.18` branch.