### PR TITLE
prepare-release: v0.17.3

### DIFF
--- a/bundle/manifests/limitador-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/limitador-operator.clusterserviceversion.yaml
@@ -36,14 +36,14 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/limitador-operator:v0.17.2
-    createdAt: "2026-05-20T16:48:46Z"
+    containerImage: quay.io/kuadrant/limitador-operator:v0.17.3
+    createdAt: "2026-07-23T14:43:27Z"
     description: The Limitador operator installs and maintains limitador instances
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/limitador-operator
     support: kuadrant
-  name: limitador-operator.v0.17.2
+  name: limitador-operator.v0.17.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -161,8 +161,8 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_LIMITADOR
-                  value: quay.io/kuadrant/limitador:v2.3.1
-                image: quay.io/kuadrant/limitador-operator:v0.17.2
+                  value: quay.io/kuadrant/limitador:v2.3.2
+                image: quay.io/kuadrant/limitador-operator:v0.17.3
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -248,6 +248,6 @@ spec:
     name: Red Hat
     url: https://github.com/Kuadrant/limitador-operator
   relatedImages:
-  - image: quay.io/kuadrant/limitador:v2.3.1
+  - image: quay.io/kuadrant/limitador:v2.3.2
     name: limitador
-  version: 0.17.2
+  version: 0.17.3

--- a/charts/limitador-operator/Chart.yaml
+++ b/charts/limitador-operator/Chart.yaml
@@ -15,8 +15,8 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The version will be properly set when the chart is released matching the operator version
-version: "0.17.2"
-appVersion: "0.17.2"
+version: "0.17.3"
+appVersion: "0.17.3"
 maintainers:
   - email: asnaps@redhat.com
     name: Alex Snaps

--- a/charts/limitador-operator/templates/manifests.yaml
+++ b/charts/limitador-operator/templates/manifests.yaml
@@ -1564,8 +1564,8 @@ spec:
         - /manager
         env:
         - name: RELATED_IMAGE_LIMITADOR
-          value: quay.io/kuadrant/limitador:v2.3.1
-        image: quay.io/kuadrant/limitador-operator:v0.17.2
+          value: quay.io/kuadrant/limitador:v2.3.2
+        image: quay.io/kuadrant/limitador-operator:v0.17.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -14,4 +14,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kuadrant/limitador-operator
-  newTag: v0.17.2
+  newTag: v0.17.3

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
             - --leader-elect
           env:
             - name: RELATED_IMAGE_LIMITADOR
-              value: "quay.io/kuadrant/limitador:v2.3.1"
+              value: "quay.io/kuadrant/limitador:v2.3.2"
           image: controller:latest
           name: manager
           securityContext:

--- a/config/manifests/bases/limitador-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/limitador-operator.clusterserviceversion.yaml
@@ -5,13 +5,13 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/limitador-operator:v0.17.2
+    containerImage: quay.io/kuadrant/limitador-operator:v0.17.3
     description: The Limitador operator installs and maintains limitador instances
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/limitador-operator
     support: kuadrant
-  name: limitador-operator.v0.17.2
+  name: limitador-operator.v0.17.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -61,4 +61,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/limitador-operator
-  version: 0.17.2
+  version: 0.17.3

--- a/make/release.mk
+++ b/make/release.mk
@@ -1,9 +1,9 @@
 #Release default values
-LIMITADOR_VERSION?=2.3.1
-IMAGE_TAG?=v0.17.2
+LIMITADOR_VERSION?=2.3.2
+IMAGE_TAG?=v0.17.3
 IMG?=quay.io/kuadrant/limitador-operator:$(IMAGE_TAG)
 BUNDLE_IMG?=quay.io/kuadrant/limitador-operator-bundle:$(IMAGE_TAG)
 CATALOG_IMG?=quay.io/kuadrant/limitador-operator-catalog:$(IMAGE_TAG)
 CHANNELS?=stable
 BUNDLE_CHANNELS?=--channels=stable
-VERSION?=0.17.2
+VERSION?=0.17.3


### PR DESCRIPTION
## Summary
- Version: 0.17.3
- Limitador: v2.3.2 (openssl 0.10.80, Clippy fixes)
- Channels: stable

Depends on limitador v2.3.2 being tagged first (PR Kuadrant/limitador#503).

🤖 Generated with [Claude Code](https://claude.com/claude-code)