### PR TITLE
Pin github actions with ratchet

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -67,25 +67,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
       - name: Login to container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # ratchet:docker/login-action@v2
         with:
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
           registry: ${{ env.IMG_REGISTRY_HOST }}
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
         with:
           images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}
           tags: |
             type=raw,value=${{ inputs.operatorTag }}
       - name: Build and Push Image
         id: build-image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # ratchet:docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
@@ -109,9 +109,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
         id: go
@@ -125,23 +125,23 @@ jobs:
             DEFAULT_CHANNEL=${{ inputs.defaultChannel }} \
             CHANNELS=${{ inputs.channels }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
       - name: Login to container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # ratchet:docker/login-action@v2
         with:
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
           registry: ${{ env.IMG_REGISTRY_HOST }}
       - name: Extract bundle metadata
         id: bundle-meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
         with:
           images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-bundle
           tags: |
             type=raw,value=${{ inputs.operatorTag }}
       - name: Build and Push Bundle Image
         id: build-bundle-image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # ratchet:docker/build-push-action@v5
         with:
           context: .
           file: ./bundle.Dockerfile
@@ -161,9 +161,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
         id: go
@@ -173,23 +173,23 @@ jobs:
             BUNDLE_IMG=${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-bundle:${{ inputs.operatorTag }} \
             DEFAULT_CHANNEL=${{ inputs.defaultChannel }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
       - name: Login to container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # ratchet:docker/login-action@v2
         with:
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
           registry: ${{ env.IMG_REGISTRY_HOST }}
       - name: Extract catalog metadata
         id: catalog-meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
         with:
           images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-catalog
           tags: |
             type=raw,value=${{ inputs.operatorTag }}
       - name: Build and Push Catalog Image
         id: build-catalog-image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # ratchet:docker/build-push-action@v5
         with:
           context: ./catalog
           file: ./catalog/${{ env.OPERATOR_NAME }}-catalog.Dockerfile

--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -18,18 +18,18 @@ jobs:
       image: ${{ steps.meta.outputs.tags }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
       - name: Login to container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # ratchet:docker/login-action@v2
         with:
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
           registry: ${{ env.IMG_REGISTRY_HOST }}
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
         with:
           images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}
           flavor: |
@@ -49,7 +49,7 @@ jobs:
       - name: Build and Push Image
         if: github.repository_owner == 'kuadrant'
         id: build-image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # ratchet:docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
@@ -74,7 +74,7 @@ jobs:
       image: ${{ steps.bundle-meta.outputs.tags }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - name: Install yq tool
         run: |
           # following sub-shells running make target should have yq already installed
@@ -90,16 +90,16 @@ jobs:
         if: ${{ needs.build.outputs.image != steps.parsed-operator-image.outputs.url }}
         run: exit 1
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
       - name: Login to container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # ratchet:docker/login-action@v2
         with:
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
           registry: ${{ env.IMG_REGISTRY_HOST }}
       - name: Extract bundle metadata
         id: bundle-meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
         with:
           images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-bundle
           flavor: |
@@ -109,7 +109,7 @@ jobs:
       - name: Build and Push Bundle Image
         if: github.repository_owner == 'kuadrant'
         id: build-bundle-image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # ratchet:docker/build-push-action@v5
         with:
           context: .
           file: ./bundle.Dockerfile
@@ -130,7 +130,7 @@ jobs:
       image: ${{ steps.catalog-meta.outputs.tags }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - name: Install yq tool
         run: |
           # following sub-shells running make target should have yq already installed
@@ -148,16 +148,16 @@ jobs:
       - name: Generate Catalog Content
         run: make catalog DEFAULT_CHANNEL=stable
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
       - name: Login to container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # ratchet:docker/login-action@v2
         with:
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
           registry: ${{ env.IMG_REGISTRY_HOST }}
       - name: Extract catalog metadata
         id: catalog-meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # ratchet:docker/metadata-action@v5
         with:
           images: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-catalog
           flavor: |
@@ -167,7 +167,7 @@ jobs:
       - name: Build and Push Catalog Image
         if: github.repository_owner == 'kuadrant'
         id: build-catalog-image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # ratchet:docker/build-push-action@v5
         with:
           context: ./catalog
           file: ./catalog/${{ env.OPERATOR_NAME }}-catalog.Dockerfile

--- a/.github/workflows/build-images-nightly.yaml
+++ b/.github/workflows/build-images-nightly.yaml
@@ -21,7 +21,7 @@ jobs:
       limitador_digest: ${{ steps.get-digest.outputs.digest }}
     steps:
       - name: Install crane
-        uses: imjasonh/setup-crane@v0.1
+        uses: imjasonh/setup-crane@5146f708a817ea23476677995bf2133943b9be0b # ratchet:imjasonh/setup-crane@v0.1
       - id: get-digest
         name: Get digest of latest limitador image
         run: |

--- a/.github/workflows/delete-release-helm-chart.yaml
+++ b/.github/workflows/delete-release-helm-chart.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - name: Parse Tag
         run: |
           tag=${{ github.event.release.tag_name || inputs.operatorTag }}

--- a/.github/workflows/issues-workflow.yaml
+++ b/.github/workflows/issues-workflow.yaml
@@ -19,7 +19,7 @@ jobs:
     if: (github.event.pull_request.head.repo.full_name == github.repository || github.event.issue.number != '') && (github.event_name == 'issues' || github.event.pull_request.user.login != 'dependabot[bot]')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@31b3f3ccdc584546fc445612dec3f38ff5edb41c # ratchet:actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/Kuadrant/projects/18
           github-token: ${{ secrets.ADD_ISSUES_TOKEN }}

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -9,9 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       operatorTag:
-          description: Operator bundle version tag
-          default: v0.0.0
-          type: string
+        description: Operator bundle version tag
+        default: v0.0.0
+        type: string
 jobs:
   chart_release:
     runs-on: ubuntu-latest
@@ -19,57 +19,57 @@ jobs:
       contents: write
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v5
-      with:
-        ref: ${{ github.ref }}
-        fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
 
-    - name: Configure Git
-      run: |
-        git config user.name "$GITHUB_ACTOR"
-        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-    - name: Configure GPG Key
-      run: |
-        mkdir -p ~/.gnupg
-        echo -n "$GPG_SIGNING_KEY" | base64 -d > ~/.gnupg/pubring.gpg
-      env:
-        GPG_SIGNING_KEY: ${{ secrets.HELM_CHARTS_SIGNING_KEY }}
+      - name: Configure GPG Key
+        run: |
+          mkdir -p ~/.gnupg
+          echo -n "$GPG_SIGNING_KEY" | base64 -d > ~/.gnupg/pubring.gpg
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.HELM_CHARTS_SIGNING_KEY }}
 
-    - name: Package Helm Chart
-      run: |
-        GPG_KEY_UID="Kuadrant Development Team" \
-        make helm-package-sign
+      - name: Package Helm Chart
+        run: |
+          GPG_KEY_UID="Kuadrant Development Team" \
+          make helm-package-sign
 
-    - name: Parse Tag
-      run: |
-        tag=${{ github.event.release.tag_name || inputs.operatorTag }}
-        echo "OPERATOR_VERSION=${tag#v}" >> $GITHUB_ENV
+      - name: Parse Tag
+        run: |
+          tag=${{ github.event.release.tag_name || inputs.operatorTag }}
+          echo "OPERATOR_VERSION=${tag#v}" >> $GITHUB_ENV
 
-    - name: Upload package to GitHub Release
-      uses: svenstaro/upload-release-action@v2
-      id: upload-chart
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: limitador-operator-${{ env.OPERATOR_VERSION }}.tgz
-        asset_name: chart-limitador-operator-${{ env.OPERATOR_VERSION }}.tgz
-        tag: ${{ github.ref }}
-        overwrite: true
+      - name: Upload package to GitHub Release
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # ratchet:svenstaro/upload-release-action@v2
+        id: upload-chart
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: limitador-operator-${{ env.OPERATOR_VERSION }}.tgz
+          asset_name: chart-limitador-operator-${{ env.OPERATOR_VERSION }}.tgz
+          tag: ${{ github.ref }}
+          overwrite: true
 
-    - name: Upload provenance file to GitHub Release
-      uses: svenstaro/upload-release-action@v2
-      id: upload-prov-file
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: limitador-operator-${{ env.OPERATOR_VERSION }}.tgz.prov
-        asset_name: chart-limitador-operator-${{ env.OPERATOR_VERSION }}.tgz.prov
-        tag: ${{ github.ref }}
-        overwrite: true
+      - name: Upload provenance file to GitHub Release
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # ratchet:svenstaro/upload-release-action@v2
+        id: upload-prov-file
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: limitador-operator-${{ env.OPERATOR_VERSION }}.tgz.prov
+          asset_name: chart-limitador-operator-${{ env.OPERATOR_VERSION }}.tgz.prov
+          tag: ${{ github.ref }}
+          overwrite: true
 
-    - name: Sync Helm Chart with repository
-      run: |
-        make helm-sync-package-created \
-          VERSION=${{env.OPERATOR_VERSION}} \
-          HELM_WORKFLOWS_TOKEN=${{ secrets.HELM_WORKFLOWS_TOKEN }} \
-          BROWSER_DOWNLOAD_URL=${{ steps.upload-chart.outputs.browser_download_url }}
+      - name: Sync Helm Chart with repository
+        run: |
+          make helm-sync-package-created \
+            VERSION=${{env.OPERATOR_VERSION}} \
+            HELM_WORKFLOWS_TOKEN=${{ secrets.HELM_WORKFLOWS_TOKEN }} \
+            BROWSER_DOWNLOAD_URL=${{ steps.upload-chart.outputs.browser_download_url }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,12 +29,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gettext-base
       - name: Checkout code at git ref
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
         with:
           ref: ${{ inputs.gitRef }}
           token: ${{ secrets.KUADRANT_DEV_PAT }}
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
         id: go
@@ -62,7 +62,7 @@ jobs:
           DEFAULT_CHANNEL=stable \
           LIMITADOR_VERSION=${{ inputs.limitadorVersion }}
       - name: Commit and push
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # ratchet:stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "Prepared release v${{ inputs.limitadorOperatorVersion }}"
           commit_user_name: "github-actions[bot]"
@@ -72,7 +72,7 @@ jobs:
           tagging_message: v${{ inputs.limitadorOperatorVersion }}
           commit_options: '--signoff'
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # ratchet:softprops/action-gh-release@v2
         with:
           name: v${{ inputs.limitadorOperatorVersion }}
           tag_name: v${{ inputs.limitadorOperatorVersion }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,13 +2,13 @@ name: Tests
 
 on:
   push:
-    branches: [ 'main', 'release-*' ]
+    branches: ['main', 'release-*']
 
   pull_request:
-    branches: [ '*' ]
+    branches: ['*']
 
   merge_group:
-    types: [ checks_requested ]
+    types: [checks_requested]
 
   workflow_dispatch:
 
@@ -22,9 +22,9 @@ jobs:
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v3.4.1
+        uses: fkirc/skip-duplicate-actions@f75dd6564bb646f95277dc8c3b80612e46a4a1ea # ratchet:fkirc/skip-duplicate-actions@v3.4.1
         with:
           cancel_others: false
           paths_ignore: '["**/*.md", "**/*.adoc", "LICENSE"]'
@@ -37,9 +37,9 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
         id: go
@@ -47,7 +47,7 @@ jobs:
         run: |
           make test-unit
       - name: Upload unit-test coverage reports to CodeCov # more at https://github.com/codecov/codecov-action
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # ratchet:codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unit
@@ -63,13 +63,13 @@ jobs:
         shell: bash
     steps:
       - name: Check out code
-        uses: actions/checkout@v5 
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@94729529f85113b88f4f819c17ce61382e6d8478 # ratchet:helm/kind-action@v1.2.0
         with:
           version: v0.22.0
           config: utils/kind-cluster.yaml
@@ -82,7 +82,7 @@ jobs:
         run: |
           make test-integration
       - name: Upload integration-test coverage reports to CodeCov # more at https://github.com/codecov/codecov-action
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # ratchet:codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: integration
@@ -94,9 +94,9 @@ jobs:
     needs: pre-job
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
         id: go
@@ -109,9 +109,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5 
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Run make verify-bundle
@@ -124,9 +124,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5 
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Run make verify-fmt
@@ -139,9 +139,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5 
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Run go mod tidy
@@ -157,9 +157,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5 
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Go Lint
@@ -171,9 +171,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5 
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Verify generate command
@@ -186,9 +186,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5 
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Verify generate command
@@ -201,22 +201,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5 
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Run make verify-helm-charts
         run: |
           make verify-helm-charts
+  verify-ratchet:
+    name: Verify ratchet
+    if: ${{ github.event_name == 'schedule' || needs.pre-job.outputs.should_skip != 'true' }}
+    needs: pre-job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Run make verify-ratchet
+        run: |
+          make verify-ratchet
   required-checks:
     name: Tests Required Checks
     # This check adds a list of checks to one job to simplify adding settings to the repo.
     # If a new check is added in this file, and it should be retested on entry to the merge queue,
     # it needs to be added to the list below aka needs: [ existing check 1, existing check 2, new check ].
-    needs: [ unit-tests, integration-tests, verify-manifests, verify-bundle, verify-fmt, verify-tidy, lint, verify-generate, verify-go-mod, verify-helm-charts ]
+    needs: [unit-tests, integration-tests, verify-manifests, verify-bundle, verify-fmt, verify-tidy, lint, verify-generate, verify-go-mod, verify-helm-charts, verify-ratchet]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # ratchet:actions/checkout@v5
       - run: echo '${{ toJSON(needs) }}' | jq -e 'all(.[]; .result == "success" or .result == "skipped")'

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ KIND ?= $(LOCALBIN)/kind
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 GINKGO ?= $(LOCALBIN)/ginkgo
 ACT ?= $(LOCALBIN)/act
+RATCHET ?= $(LOCALBIN)/ratchet
 
 ## Tool Versions
 OPERATOR_SDK_VERSION ?= v1.32.0
@@ -151,6 +152,7 @@ HELM_VERSION ?= v3.15.0
 KIND_VERSION ?= v0.23.0
 GOLANGCI_LINT_VERSION ?= v2.12.2
 ACT_VERSION ?= latest
+RATCHET_VERSION ?= v0.11.4
 
 ## Versioned Binaries (the actual files that 'make' will check for)
 OPERATOR_SDK_V_BINARY := $(LOCALBIN)/operator-sdk-$(OPERATOR_SDK_VERSION)
@@ -162,6 +164,7 @@ HELM_V_BINARY := $(LOCALBIN)/helm-$(HELM_VERSION)
 KIND_V_BINARY := $(LOCALBIN)/kind-$(KIND_VERSION)
 GOLANGCI_LINT_V_BINARY := $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 ACT_V_BINARY := $(LOCALBIN)/act-$(ACT_VERSION)
+RATCHET_V_BINARY := $(LOCALBIN)/ratchet-$(RATCHET_VERSION)
 
 .PHONY: operator-sdk
 operator-sdk: $(OPERATOR_SDK_V_BINARY) ## Download operator-sdk locally if necessary.
@@ -222,6 +225,11 @@ $(GINKGO): $(LOCALBIN) go.mod
 act: $(ACT_V_BINARY) ## Download act locally if necessary.
 $(ACT_V_BINARY): $(LOCALBIN)
 	$(call go-install-tool,$(ACT),github.com/nektos/act,$(ACT_VERSION))
+
+.PHONY: ratchet
+ratchet: $(RATCHET_V_BINARY) ## Download ratchet locally if necessary.
+$(RATCHET_V_BINARY): $(LOCALBIN)
+	$(call go-install-tool,$(RATCHET),github.com/sethvargo/ratchet,$(RATCHET_VERSION))
 
 ##@ General
 
@@ -466,6 +474,10 @@ local-redeploy: ## re-deploy operator in local kind cluster
 .PHONY: run-lint
 run-lint: golangci-lint ## Run lint tests
 	$(GOLANGCI_LINT) run
+
+.PHONY: ratchet-pin
+ratchet-pin: ratchet ## Pin GitHub Actions to commit SHAs.
+	$(RATCHET) pin $$(find .github/workflows -name '*.yaml' -o -name '*.yml')
 
 # Include last to avoid changing MAKEFILE_LIST used above
 include ./make/*.mk

--- a/make/verify.mk
+++ b/make/verify.mk
@@ -34,3 +34,7 @@ verify-go-mod: ## Verify go.mod matches source code
 verify-helm-charts: helm-build ## Verify helm charts update.
 	git diff --exit-code ./charts
 	[ -z "$$(git ls-files --other --exclude-standard --directory --no-empty-directory ./charts)" ]
+
+.PHONY: verify-ratchet
+verify-ratchet: ratchet ## Verify GitHub Actions are pinned to commit SHAs.
+	$(RATCHET) lint $$(find .github/workflows -name '*.yaml' -o -name '*.yml')


### PR DESCRIPTION
## Summary
  - Pin all GitHub Action references to commit SHAs using [ratchet](https://github.com/sethvargo/ratchet)
  - Add `ratchet-pin` and `verify-ratchet` Make targets for pinning and verifying action references
  - Add `verify-ratchet` job to the existing CI workflow to block PRs with unpinned action references

  Part of the work on https://github.com/Kuadrant/kuadrant-operator/issues/2055

  ## Motivation
  Tags are mutable — action maintainers can force-push them, silently changing the code our CI runs. Pinning to commit SHAs makes each reference immutable, mitigating supply-chain attacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Pinned workflow actions to immutable revisions, improving build and release reproducibility.
  * Added automated verification to detect unpinned workflow actions.

* **Maintenance**
  * Added tooling to pin and validate workflow action revisions.
  * Preserved existing build, test, chart, and release behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->